### PR TITLE
RSDK-4281: Shutting down viam-server causes intel realsense module to seg-fault if the component is currently running

### DIFF
--- a/etc/Dockerfile.cuda.debian.bookworm
+++ b/etc/Dockerfile.cuda.debian.bookworm
@@ -93,7 +93,7 @@ RUN apt install -y \
 RUN pip3 install -U pip setuptools urllib3==1.26.12 requests==2.26.0 --break-system-packages
 
 # install appimage-builder
-RUN pip3 install --break-system-packages git+https://github.com/AppImageCrafters/appimage-builder.git@f38699ef3644fa5409a5a262b7b6d99d6fb85db9
+RUN pip3 install --break-system-packages git+https://github.com/AppImageCrafters/appimage-builder.git@61c8ddde9ef44b85d7444bbe79d80b44a6a5576d
 
 # install Go
 RUN apt install -y golang-go 

--- a/etc/Dockerfile.debian.bookworm
+++ b/etc/Dockerfile.debian.bookworm
@@ -88,7 +88,7 @@ RUN apt install -y \
 RUN pip3 install -U pip setuptools urllib3==1.26.12 requests==2.26.0 --break-system-packages
 
 # install appimage-builder
-RUN pip3 install --break-system-packages git+https://github.com/AppImageCrafters/appimage-builder.git@f38699ef3644fa5409a5a262b7b6d99d6fb85db9
+RUN pip3 install --break-system-packages git+https://github.com/AppImageCrafters/appimage-builder.git@61c8ddde9ef44b85d7444bbe79d80b44a6a5576d
 
 # install Go
 RUN apt install -y golang-go 

--- a/packaging/appimages/viam-camera-realsense-aarch64.yml
+++ b/packaging/appimages/viam-camera-realsense-aarch64.yml
@@ -44,4 +44,5 @@ AppDir:
         AIX_TARGET: usr/bin/viam-camera-realsense
 AppImage:
   arch: aarch64
+  comp: gzip
   update-information: zsync|http://packages.viam.com/apps/camera-servers/viam-camera-realsense-${TAG_NAME}-aarch64.AppImage.zsync

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -460,7 +460,6 @@ CameraRealSense::~CameraRealSense() {
     std::unique_lock<std::mutex> lock(this->device_->mutex);
     this->device_->shouldRun = false;
     this->device_->cv.wait(lock, [this] { return !(device_->isRunning); });
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
 
 void CameraRealSense::reconfigure(sdk::Dependencies deps, sdk::ResourceConfig cfg) {

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -460,6 +460,7 @@ CameraRealSense::~CameraRealSense() {
     std::unique_lock<std::mutex> lock(this->device_->mutex);
     this->device_->shouldRun = false;
     this->device_->cv.wait(lock, [this] { return !(device_->isRunning); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
 
 void CameraRealSense::reconfigure(sdk::Dependencies deps, sdk::ResourceConfig cfg) {


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-4281

## Context for why this solution (hopefully) works

I built the module as a pure binary and tried repro-ing as per the ticket. Could not get it to repro after many attempts. Figured it might be an appimage issue. AppImages are still pretty black-box to me. Did the most sane thing 😂 and just bumped our dependency to a more recent version. Issue seems to be gone: tested on my RPI and Ubuntu setups

Further context: I analyzed a coredump of the crash, and this is what I saw in the stack and threads
![image](https://github.com/viamrobotics/viam-camera-realsense/assets/55464069/fae87d66-32de-44f6-b758-65429993e47b). `libgio` appears. The only thing I can think of that might depend on this is the AppImage stuff. Adding @abe-winter to fact check this.

Further further context: I know on the ticket it was mentioned that this bug is only reproducible when the stream is on. I `gdb attach`ed to the binary process during termination and the result was:
```
Thread 25 "grpcpp_sync_ser" received signal SIGSEGV, Segmentation fault.
[Switching to LWP 24522]
0x0000ffffb9531ea4 in pthread_mutex_lock () from /tmp/.mount_viam-c6axjgw/runtime/compat/lib/aarch64-linux-gnu/libc.so.6
```
My guess is the AppImage and the grpcpp dep aren't playing well together and are not freeing memory + terminating properly?

## Testing
Could someone also test on their machine(s) to verify?

[Download AppImage](https://drive.google.com/file/d/1gLZH0az6N7V_XZTTIshfsk5LtCfOhMim/view?usp=sharing)