### PR TITLE
RSDK-4281: Segfault on Shutdown (fix attempt 2)

### DIFF
--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -634,6 +634,7 @@ void frameLoop(rs2::pipeline pipeline, std::promise<void>& ready,
         {
             std::lock_guard<std::mutex> lock(deviceProps->mutex);
             if (!deviceProps->shouldRun) {
+                ctx = rs2::context();  // deregisters callback
                 pipeline.stop();
                 std::cout << "[frameLoop] pipeline stopped, exiting frame loop" << std::endl;
                 break;


### PR DESCRIPTION
I bit the bullet today and did the "comment out code until it stops breaking" methodology of debugging. I narrowed down what seems to be the segment of code that is actually breaking the module on repro shutdown— not 100% sure though because the repro steps are non-deterministic. However, I made the code change on this PR, and I tried the repro steps like 20 times again, and it didn't segfault, while previous code segfaulted multiple times.

@seanavery I think it might be worth it to try it a couple times and see if it segfaults on your end if you have time today or tomorrow tysm

https://drive.google.com/file/d/1lJMWIZBnNZYCyW47yRqbzhOUypLkxsMm/view?usp=sharing