### PR TITLE
Add safety conditional for preprocessor macro

### DIFF
--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -28,8 +28,10 @@
 #include "third_party/fpng.h"
 #include "third_party/lodepng.h"
 
+#ifndef htonll
 #define htonll(x) \
     ((1 == htonl(1)) ? (x) : ((uint64_t)htonl((x)&0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#endif
 
 namespace {
 bool debug_enabled = false;


### PR DESCRIPTION
[PR in C++ SDK will define `htonll`.](https://github.com/viamrobotics/viam-cpp-sdk/pull/213) Will break the module if we upgrade. This fixes it