### PR TITLE
RSDK-6718: Intel camera not reconnecting

### DIFF
--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -876,12 +876,6 @@ void on_device_reconnect(rs2::event_information& info, rs2::pipeline pipeline,
         ready.get_future().wait();
         std::cout << "camera frame loop ready!" << std::endl;
         cameraThread.detach();
-    } else {
-        std::cout << "Device disconnected, stopping frame pipeline" << std::endl;
-        {
-            std::lock_guard<std::mutex> lock(device->mutex);
-            device->shouldRun = false;
-        }
     }
 };
 

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -634,7 +634,6 @@ void frameLoop(rs2::pipeline pipeline, std::promise<void>& ready,
         {
             std::lock_guard<std::mutex> lock(deviceProps->mutex);
             if (!deviceProps->shouldRun) {
-                ctx = rs2::context();  // deregisters callback
                 pipeline.stop();
                 std::cout << "[frameLoop] pipeline stopped, exiting frame loop" << std::endl;
                 break;
@@ -848,6 +847,9 @@ void on_device_reconnect(rs2::event_information& info, rs2::pipeline pipeline,
     if (device == nullptr) {
         throw std::runtime_error(
             "no device info to reconnect to. RealSense device was never initialized.");
+    }
+    if (!device->shouldRun) {
+        return;
     }
     if (info.was_added(info.get_new_devices().front())) {
         std::cout << "Device was reconnected, restarting pipeline" << std::endl;


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-6718

The patch that fixed the segfault bug resulted in this bug ^

The previous patch's solution was to reinitialize the rs2 context, which causes the pipeline restart to fail silently as seen on the ticket. Instead of using that strategy to deregister the callback-- we won't. We should just add a guard clause so that the callback won't ever access freed resources