### PR TITLE
RSDK-6710: Consume C++ SDK Depth Transcoders pt.1 (Bump C++ SDK version)

### DIFF
--- a/etc/Dockerfile.cuda.debian.bookworm
+++ b/etc/Dockerfile.cuda.debian.bookworm
@@ -52,7 +52,7 @@ RUN sed -i 's/Components: main/Components: main contrib non-free non-free-firmwa
 RUN mkdir -p /root/opt/src
 
 # install Viam C++ SDK from source frozen at a commit
-ENV PINNED_COMMIT_HASH="802b70b234741d17345be77b4e52f39e4c40a252"
+ENV PINNED_COMMIT_HASH="fea4268e711ac663f95283be48373c740c56eecf"
 RUN cd /root/opt/src && \
     git clone https://github.com/viamrobotics/viam-cpp-sdk && \
     cd viam-cpp-sdk && \

--- a/etc/Dockerfile.debian.bookworm
+++ b/etc/Dockerfile.debian.bookworm
@@ -47,7 +47,7 @@ RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bookworm-15 \
 RUN mkdir -p /root/opt/src
 
 # install Viam C++ SDK from source frozen at a commit
-ENV PINNED_COMMIT_HASH="802b70b234741d17345be77b4e52f39e4c40a252"
+ENV PINNED_COMMIT_HASH="fea4268e711ac663f95283be48373c740c56eecf"
 RUN cd /root/opt/src && \
     git clone https://github.com/viamrobotics/viam-cpp-sdk && \
     cd viam-cpp-sdk && \


### PR DESCRIPTION
We need the Docker container that builds the Realsense to have the latest version of the C++ SDK in order to consume the latest depth transcoder changes