### PR TITLE
[RSDK-6710] Consume depth map transcoders from C++ SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ module.tar.gz
 *.AppImage
 integration/realsense-integration-tests
 realsense-integration-tests
-
+.vscode

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -28,9 +28,6 @@
 #include "third_party/fpng.h"
 #include "third_party/lodepng.h"
 
-#define htonll(x) \
-    ((1 == htonl(1)) ? (x) : ((uint64_t)htonl((x)&0xFFFFFFFF) << 32) | htonl((x) >> 32))
-
 namespace {
 bool debug_enabled = false;
 const uint32_t rgbaMagicNumber =
@@ -41,15 +38,6 @@ const size_t rgbaWidthByteCount =
     sizeof(uint32_t);  // number of bytes used to represent rgba image width
 const size_t rgbaHeightByteCount =
     sizeof(uint32_t);  // number of bytes used to represent rgba image height
-
-const uint64_t depthMagicNumber =
-    htonll(4919426490892632400);  // the utf-8 binary encoding for "DEPTHMAP", big-endian
-const size_t depthMagicByteCount =
-    sizeof(uint64_t);  // number of bytes used to represent the depth magic number
-const size_t depthWidthByteCount =
-    sizeof(uint64_t);  // number of bytes used to represent depth image width
-const size_t depthHeightByteCount =
-    sizeof(uint64_t);  // number of bytes used to represent depth image height
 
 // COLOR responses
 struct color_response {
@@ -252,40 +240,17 @@ std::unique_ptr<viam::sdk::Camera::raw_image> encodeDepthPNGToResponse(const uns
 
 raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
                                 const uint64_t height, const bool littleEndian) {
-    std::chrono::time_point<std::chrono::high_resolution_clock> start;
     if (debug_enabled) {
         start = std::chrono::high_resolution_clock::now();
     }
-    // Depth header contains 8 bytes worth of magic number, followed by 8 bytes for width and
-    // another 8 bytes for height each pixel has 2 bytes.
-    size_t pixelByteCount = 2 * width * height;
-    uint64_t widthToEncode = htonll(width);    // make sure everything is big-endian
-    uint64_t heightToEncode = htonll(height);  // make sure everything is big-endian
-    size_t totalByteCount =
-        depthMagicByteCount + depthWidthByteCount + depthHeightByteCount + pixelByteCount;
-    // memcpy data into buffer
-    raw_camera_image::uniq rawBuf(new unsigned char[totalByteCount],
-                                  raw_camera_image::array_delete_deleter);
-    int offset = 0;
-    std::memcpy(rawBuf.get() + offset, &depthMagicNumber, depthMagicByteCount);
-    offset += depthMagicByteCount;
-    std::memcpy(rawBuf.get() + offset, &widthToEncode, depthWidthByteCount);
-    offset += depthWidthByteCount;
-    std::memcpy(rawBuf.get() + offset, &heightToEncode, depthHeightByteCount);
-    offset += depthHeightByteCount;
-    if (littleEndian) {
-        std::memcpy(rawBuf.get() + offset, data, pixelByteCount);
-    } else {
-        int pixelOffset = 0;
-        for (int i = 0; i < width * height; i++) {
-            uint16_t pix;
-            std::memcpy(&pix, data + pixelOffset, 2);
-            uint16_t pixEncode = htons(pix);  // make sure the pixel values are big-endian
-            std::memcpy(rawBuf.get() + offset, &pixEncode, 2);
-            pixelOffset += 2;
-            offset += 2;
-        }
-    }
+
+    auto m = xt::xadapt(reinterpret_cast<const uint16_t*>(data), height * width,
+                        xt::no_ownership(), {height, width});
+    sdk::Camera camera;
+    std::vector<unsigned char> encodedData = camera.encode_depth_map(m);
+
+    unsigned char* rawBuf = new unsigned char[encodedData.size()];
+    std::memcpy(rawBuf, encodedData.data(), encodedData.size());
 
     if (debug_enabled) {
         auto stop = std::chrono::high_resolution_clock::now();
@@ -293,7 +258,7 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
         std::cout << "[GetImage]  RAW depth encode:      " << duration.count() << "ms\n";
     }
 
-    return {std::move(rawBuf), std::move(totalByteCount)};
+    return raw_camera_image{raw_camera_image::uniq(rawBuf, raw_camera_image::array_delete_deleter), encodedData.size()};
 }
 
 std::unique_ptr<viam::sdk::Camera::raw_image> encodeDepthRAWToResponse(const unsigned char* data,

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -244,8 +244,8 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
         start = std::chrono::high_resolution_clock::now();
     }
 
-    auto m = xt::xadapt(reinterpret_cast<const uint16_t*>(data), height * width,
-                        xt::no_ownership(), {height, width});
+    auto m = xt::xadapt(reinterpret_cast<const uint16_t*>(data), height * width, xt::no_ownership(),
+                        {height, width});
     sdk::Camera camera;
     std::vector<unsigned char> encodedData = camera.encode_depth_map(m);
 
@@ -258,7 +258,8 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
         std::cout << "[GetImage]  RAW depth encode:      " << duration.count() << "ms\n";
     }
 
-    return raw_camera_image{raw_camera_image::uniq(rawBuf, raw_camera_image::array_delete_deleter), encodedData.size()};
+    return raw_camera_image{raw_camera_image::uniq(rawBuf, raw_camera_image::array_delete_deleter),
+                            encodedData.size()};
 }
 
 std::unique_ptr<viam::sdk::Camera::raw_image> encodeDepthRAWToResponse(const unsigned char* data,
@@ -885,13 +886,11 @@ std::vector<std::string> validate(sdk::ResourceConfig cfg) {
 
 int serve(int argc, char** argv) {
     std::shared_ptr<sdk::ModelRegistration> mr = std::make_shared<sdk::ModelRegistration>(
-        sdk::API::get<sdk::Camera>(),
-        sdk::Model{kAPINamespace, kAPIType, kAPISubtype},
+        sdk::API::get<sdk::Camera>(), sdk::Model{kAPINamespace, kAPIType, kAPISubtype},
         [](sdk::Dependencies deps, sdk::ResourceConfig cfg) -> std::shared_ptr<sdk::Resource> {
             return std::make_unique<CameraRealSense>(deps, cfg);
         },
-        validate
-    );
+        validate);
 
     std::vector<std::shared_ptr<sdk::ModelRegistration>> mrs = {mr};
     auto module_service = std::make_shared<sdk::ModuleService>(argc, argv, mrs);

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -431,7 +431,7 @@ CameraRealSense::~CameraRealSense() {
     this->device_->cv.wait(lock, [this] { return !(device_->isRunning); });
 }
 
-void CameraRealSense::reconfigure(sdk::Dependencies deps, sdk::ResourceConfig cfg) {
+void CameraRealSense::reconfigure(const sdk::Dependencies& deps, const sdk::ResourceConfig& cfg) {
     RealSenseProperties props;
     bool disableColor;
     bool disableDepth;

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -244,7 +244,7 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
         start = std::chrono::high_resolution_clock::now();
     }
 
-    auto m = xt::xadapt(reinterpret_cast<const uint16_t*>(data), height * width, xt::no_ownership(),
+    sdk::Camera::depth_map m = xt::xadapt(reinterpret_cast<const uint16_t*>(data), height * width, xt::no_ownership(),
                         {height, width});
     sdk::Camera camera;
     std::vector<unsigned char> encodedData = camera.encode_depth_map(m);

--- a/src/camera_realsense.hpp
+++ b/src/camera_realsense.hpp
@@ -14,6 +14,7 @@
 #include <viam/sdk/components/component.hpp>
 #include <viam/sdk/module/service.hpp>
 #include <viam/sdk/registry/registry.hpp>
+#include <viam/sdk/resource/reconfigurable.hpp>
 #include <viam/sdk/rpc/server.hpp>
 
 namespace viam {
@@ -96,7 +97,7 @@ std::vector<std::string> validate(sdk::ResourceConfig cfg);
 int serve(int argc, char** argv);
 
 // The camera module class and its methods
-class CameraRealSense : public sdk::Camera {
+class CameraRealSense : public sdk::Camera, public sdk::Reconfigurable {
    private:
     std::shared_ptr<DeviceProperties> device_;
     RealSenseProperties props_;
@@ -107,7 +108,7 @@ class CameraRealSense : public sdk::Camera {
    public:
     explicit CameraRealSense(sdk::Dependencies deps, sdk::ResourceConfig cfg);
     ~CameraRealSense();
-    void reconfigure(sdk::Dependencies deps, sdk::ResourceConfig cfg);
+    void reconfigure(const sdk::Dependencies& deps, const sdk::ResourceConfig& cfg) override;
     sdk::Camera::raw_image get_image(std::string mime_type,
                                      const sdk::AttributeMap& extra) override;
     sdk::Camera::properties get_properties() override;

--- a/src/camera_realsense.hpp
+++ b/src/camera_realsense.hpp
@@ -10,8 +10,7 @@
 #include <thread>
 #include <tuple>
 #include <vector>
-#include <viam/sdk/components/camera/camera.hpp>
-#include <viam/sdk/components/camera/server.hpp>
+#include <viam/sdk/components/camera.hpp>
 #include <viam/sdk/components/component.hpp>
 #include <viam/sdk/module/service.hpp>
 #include <viam/sdk/registry/registry.hpp>
@@ -108,12 +107,12 @@ class CameraRealSense : public sdk::Camera {
    public:
     explicit CameraRealSense(sdk::Dependencies deps, sdk::ResourceConfig cfg);
     ~CameraRealSense();
-    void reconfigure(sdk::Dependencies deps, sdk::ResourceConfig cfg) override;
+    void reconfigure(sdk::Dependencies deps, sdk::ResourceConfig cfg);
     sdk::Camera::raw_image get_image(std::string mime_type,
                                      const sdk::AttributeMap& extra) override;
     sdk::Camera::properties get_properties() override;
     sdk::Camera::image_collection get_images() override;
-    sdk::AttributeMap do_command(sdk::AttributeMap command) override;
+    sdk::AttributeMap do_command(const sdk::AttributeMap& command) override;
     sdk::Camera::point_cloud get_point_cloud(std::string mime_type,
                                              const sdk::AttributeMap& extra) override;
     std::vector<sdk::GeometryConfig> get_geometries(const sdk::AttributeMap& extra) override;


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-6710

tl;dr [C++ SDK now has support for encoding depth maps built in](https://github.com/viamrobotics/viam-cpp-sdk/pull/213). We should use it instead of having custom logic inside module scope

This PR follows [a bump in our C++ SDK dep in the Dockerfiles](https://github.com/viamrobotics/viam-camera-realsense/pull/35)

Tests:
Depth stream 
<img width="1470" alt="Screenshot 2024-04-15 at 4 11 51 PM" src="https://github.com/viamrobotics/viam-camera-realsense/assets/55464069/8f4294b1-d6f4-4e85-b7e4-55383efceee9">

Pointclouds (via join_color_depth)
<img width="1470" alt="Screenshot 2024-04-15 at 4 46 25 PM" src="https://github.com/viamrobotics/viam-camera-realsense/assets/55464069/ff767ea6-f3e4-4f12-a256-82f789430fe6">

Color stream
<img width="1470" alt="Screenshot 2024-04-15 at 4 52 59 PM" src="https://github.com/viamrobotics/viam-camera-realsense/assets/55464069/bb59a1ac-6dec-4846-a8bf-bcf66ea20f78">


Verified it reconfigures and reconnects on unplug-plug