### PR TITLE
RSDK-7243   (FIX) Polish hacky build for Realsense linux/amd64 and make it official CI to publish to registry

### DIFF
--- a/.github/workflows/appimage-tag.yml
+++ b/.github/workflows/appimage-tag.yml
@@ -1,4 +1,4 @@
-name: Build AppImage Intel RealSense
+name: Build AppImage and publish to registry
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -6,8 +6,8 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    tags:
-      - '*'
+    # tags:
+    #   - '*'
 
 jobs:
   appimage:
@@ -43,7 +43,7 @@ jobs:
 
       - name: bundle module
         run: |
-          cp packaging/appimages/deploy/viam-camera-realsense-${{ github.ref_name }}-${{ matrix.appimage_arch_name }}.AppImage viam-camera-realsense.AppImage
+          cp packaging/appimages/deploy/viam-camera-realsense-*.AppImage viam-camera-realsense.AppImage
           tar czf module.tar.gz viam-camera-realsense.AppImage
 
       - uses: viamrobotics/upload-module@main

--- a/.github/workflows/appimage-tag.yml
+++ b/.github/workflows/appimage-tag.yml
@@ -22,14 +22,12 @@ jobs:
               image: ghcr.io/viamrobotics/viam-camera-realsense:arm64
               options: --platform linux/arm64
             make_target: appimage-arm64
-            appimage_arch_name: aarch64
             platform: linux/arm64
           - os: ubuntu-latest
             container:
               image: ghcr.io/viamrobotics/viam-camera-realsense:amd64
               options: --platform linux/amd64
             make_target: appimage-amd64
-            appimage_arch_name: x86_64
             platform: linux/amd64
 
     container: ${{ matrix.container }}

--- a/.github/workflows/appimage-tag.yml
+++ b/.github/workflows/appimage-tag.yml
@@ -6,8 +6,8 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    # tags:
-    #   - '*'
+    tags:
+      - '*'
 
 jobs:
   appimage:


### PR DESCRIPTION
the `appimage-tag.yml` flow (in charge of building and publishing) is breaking on main. I should've tested this sorry