### PR TITLE
[RSDK-8195]   Set `supports_pcd` to true in RealSense

### DIFF
--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -77,15 +77,6 @@ std::tuple<RealSenseProperties, bool, bool> CameraRealSense::initialize(sdk::Res
             littleEndianDepth = endian_bool;
         }
     }
-    bool enablePointClouds = false;
-    if (attrs->count("enable_point_clouds") == 1) {
-        std::shared_ptr<sdk::ProtoType> pointclouds_proto = attrs->at("enable_point_clouds");
-        auto pointclouds_value = pointclouds_proto->proto_value();
-        if (pointclouds_value.has_bool_value()) {
-            bool pointclouds_bool = static_cast<bool>(pointclouds_value.bool_value());
-            enablePointClouds = pointclouds_bool;
-        }
-    }
     bool disableDepth = true;
     bool disableColor = true;
     std::vector<std::string> sensors;
@@ -132,9 +123,6 @@ std::tuple<RealSenseProperties, bool, bool> CameraRealSense::initialize(sdk::Res
         std::cout << std::boolalpha << "depth little endian encoded: " << littleEndianDepth
                   << std::endl;
     }
-    props.enablePointClouds = enablePointClouds;
-    std::string pointcloudString = (enablePointClouds) ? "true" : "false";
-    std::cout << "point clouds enabled: " << pointcloudString << std::endl;
     std::promise<void> ready;
     std::thread cameraThread(frameLoop, pipe, ref(ready), device_, props.depthScaleMm);
     std::cout << "waiting for camera frame loop thread to be ready..." << std::endl;

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -238,8 +238,8 @@ sdk::Camera::raw_image CameraRealSense::get_image(std::string mime_type,
 }
 
 sdk::Camera::properties CameraRealSense::get_properties() {
-    auto fillResp = [](sdk::Camera::properties* p, CameraProperties props, bool supportsPCD) {
-        p->supports_pcd = supportsPCD;
+    auto fillResp = [](sdk::Camera::properties* p, CameraProperties props) {
+        p->supports_pcd = true;
         p->intrinsic_parameters.width_px = props.width;
         p->intrinsic_parameters.height_px = props.height;
         p->intrinsic_parameters.focal_x_px = props.fx;
@@ -253,12 +253,10 @@ sdk::Camera::properties CameraRealSense::get_properties() {
     };
 
     sdk::Camera::properties response{};
-    // pcd enabling will be a config parameter, for now, just put false
-    bool pcdEnabled = false;
     if (this->props_.mainSensor.compare("color") == 0) {
-        fillResp(&response, this->props_.color, pcdEnabled);
+        fillResp(&response, this->props_.color);
     } else if (props_.mainSensor.compare("depth") == 0) {
-        fillResp(&response, this->props_.depth, pcdEnabled);
+        fillResp(&response, this->props_.depth);
     }
 
     return response;

--- a/src/camera_realsense.hpp
+++ b/src/camera_realsense.hpp
@@ -68,7 +68,6 @@ struct RealSenseProperties {
     std::string mainSensor;
     std::vector<std::string> sensors;
     bool littleEndianDepth;
-    bool enablePointClouds;
 };
 
 struct PipelineWithProperties {


### PR DESCRIPTION
[RSDK-8195](https://viam.atlassian.net/browse/RSDK-8195)

Forgot to change properties after adding new pcd method

Tested with robot usage of RealSense as a dependency for the join-point-clouds module to [verify that we can invoke get_properties properly and that pcd support is now true](https://github.com/viam-modules/join-point-clouds/blob/a473eac1b52801f34492936746017e00f2e140ac/src/main.cpp#L48)

[RSDK-8195]: https://viam.atlassian.net/browse/RSDK-8195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ