### PR TITLE
Bump sdk and rearrange dockerfiles

### DIFF
--- a/etc/Dockerfile.cuda.debian.bookworm
+++ b/etc/Dockerfile.cuda.debian.bookworm
@@ -105,8 +105,6 @@ RUN cd /root/opt/src && \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON -DVIAMCPPSDK_OFFLINE_PROTO_GENERATION=ON \
     -DCMAKE_INSTALL_PREFIX=/usr/local \
-    -DCMAKE_C_COMPILER=/usr/bin/clang-15 \
-    -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 \
     .. -G Ninja  && \
     ninja all -j 4 && \
     ninja install -j 4 && \

--- a/etc/Dockerfile.debian.bookworm
+++ b/etc/Dockerfile.debian.bookworm
@@ -100,8 +100,6 @@ RUN cd /root/opt/src && \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON -DVIAMCPPSDK_OFFLINE_PROTO_GENERATION=ON \
     -DCMAKE_INSTALL_PREFIX=/usr/local \
-    -DCMAKE_C_COMPILER=/usr/bin/clang-15 \
-    -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 \
     .. -G Ninja  && \
     ninja all -j 4 && \
     ninja install -j 4 && \


### PR DESCRIPTION
This PR bumps the SDK version to consume team-sdk's fix for zombied cpp modules after viam-server hard kill.

It also rearranges the build order to make iterative builds more convenient.

## Tests
On orin nano: https://www.loom.com/share/601cb1864d264643bdc71629c17069cb?sid=01c85257-6abd-4bc0-b95e-1e64caf73c32

Didn't take a video, but observed same correct behavior on linux/amd64 framework laptop