### PR TITLE
[RSDK-13785] Force libzip to link statically via Conan

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -78,7 +78,7 @@ jobs:
           make module.tar.gz
 
       - name: Upload module artifact
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,43 +58,23 @@ jobs:
             exit 1
           fi
 
-      - name: Build with coverage (Linux amd64 only)
+      - name: Install lcov (Linux amd64 only)
         if: matrix.coverage == true
-        run: |
-          . ./venv/bin/activate
-          GENERATORS="$(pwd)/build-conan/build/Release/generators"
-          mkdir -p build-native && cd build-native
-          cmake .. \
-            -DVIAM_REALSENSE_ENABLE_TESTS=ON \
-            -DVIAM_REALSENSE_ENABLE_COVERAGE=ON \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_TOOLCHAIN_FILE="$GENERATORS/conan_toolchain.cmake" \
-            -DCMAKE_PREFIX_PATH="$GENERATORS"
-          make -j$(nproc)
+        run: sudo apt-get update && sudo apt-get install -y lcov
 
-      - name: Build without coverage (other platforms)
+      - name: Build and run tests with coverage (Linux amd64 only)
+        if: matrix.coverage == true
+        run: make test-coverage
+
+      - name: Build and run tests (other platforms)
         if: matrix.coverage != true
-        run: make build-native
-
-      - name: Run the tests
-        run: |
-          . ./build-conan/build/Release/generators/conanrun.sh
-          cd build-native && ctest --output-on-failure
-
-      - name: Generate coverage report
-        if: matrix.coverage == true
-        run: |
-          sudo apt-get update && sudo apt-get install -y lcov
-          cd build-native
-          lcov --capture --directory . --output-file coverage.info
-          lcov --remove coverage.info '/usr/*' '*/test/*' '*/build-native/_deps/*' --output-file coverage.info
-          lcov --list coverage.info
+        run: make test
 
       - name: Upload coverage reports to Codecov
         if: matrix.coverage == true
         uses: codecov/codecov-action@v5
         with:
-          files: ./build-native/coverage.info
+          files: ./build-conan/coverage.info
           flags: unittests
           # Token is optional for public repos, but recommended for reliability
           # If uploads fail, ensure CODECOV_TOKEN is set in repository secrets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ on:
 jobs:
   run-tests:
     name: Run Tests
-    timeout-minutes: 10
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - os: buildjet-8vcpu-ubuntu-2204-arm
+          - os: github-linux-arm64-8core
             container:
               image: ghcr.io/viam-modules/viam-camera-realsense:arm64
               options: --platform linux/arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   run-tests:
     name: Run Tests
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        if: runner.os == 'macOS'
         run: |
           make setup
           test -f ./venv/bin/activate && . ./venv/bin/activate && conan profile show
-      
+
+      - name: Install Conan dependencies
+        run: |
+          make conan-install-test
+
       - name: Lint
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -55,16 +58,18 @@ jobs:
             exit 1
           fi
 
-      - name: Install Conan dependencies
-        if: runner.os == 'macOS'
-        run: |
-          make conan-install-test
-
       - name: Build with coverage (Linux amd64 only)
         if: matrix.coverage == true
         run: |
+          . ./venv/bin/activate
+          GENERATORS="$(pwd)/build-conan/build/Release/generators"
           mkdir -p build-native && cd build-native
-          cmake .. -DVIAM_REALSENSE_ENABLE_TESTS=ON -DVIAM_REALSENSE_ENABLE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Release
+          cmake .. \
+            -DVIAM_REALSENSE_ENABLE_TESTS=ON \
+            -DVIAM_REALSENSE_ENABLE_COVERAGE=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="$GENERATORS/conan_toolchain.cmake" \
+            -DCMAKE_PREFIX_PATH="$GENERATORS"
           make -j$(nproc)
 
       - name: Build without coverage (other platforms)
@@ -72,7 +77,9 @@ jobs:
         run: make build-native
 
       - name: Run the tests
-        run: cd build-native && ctest --output-on-failure
+        run: |
+          . ./build-conan/build/Release/generators/conanrun.sh
+          cd build-native && ctest --output-on-failure
 
       - name: Generate coverage report
         if: matrix.coverage == true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,14 +32,7 @@ find_package(realsense2 REQUIRED)
 find_package(viam-cpp-sdk REQUIRED)
 find_package(libjpeg-turbo CONFIG REQUIRED)
 find_package(CURL REQUIRED)
-find_package(PkgConfig REQUIRED)
-
-# Use pkg-config for libzip when available (more reliable with system packages)
-# Fall back to find_package for Conan-provided libzip
-pkg_check_modules(LIBZIP IMPORTED_TARGET libzip)
-if(NOT LIBZIP_FOUND)
-    find_package(libzip REQUIRED)
-endif()
+find_package(libzip REQUIRED)
 
 add_library(viamrealsense
     src/module/encoding.cpp
@@ -61,7 +54,7 @@ target_link_libraries(viamrealsense
         realsense2::realsense2
         libjpeg-turbo::turbojpeg-static
         CURL::libcurl
-        $<IF:$<TARGET_EXISTS:PkgConfig::LIBZIP>,PkgConfig::LIBZIP,libzip::zip>
+        libzip::zip
     PRIVATE
         ${CMAKE_DL_LIBS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,16 +32,7 @@ find_package(realsense2 REQUIRED)
 find_package(viam-cpp-sdk REQUIRED)
 find_package(libjpeg-turbo CONFIG REQUIRED)
 find_package(CURL REQUIRED)
-
-# Conan 2.x always names its toolchain "conan_toolchain.cmake". Use that to
-# distinguish Conan builds (where find_package finds Conan's static libzip)
-# from native builds (where the system cmake config for libzip may be broken).
-if(CMAKE_TOOLCHAIN_FILE MATCHES "conan_toolchain")
-    find_package(libzip REQUIRED)
-else()
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(LIBZIP REQUIRED IMPORTED_TARGET libzip)
-endif()
+find_package(libzip REQUIRED)
 
 add_library(viamrealsense
     src/module/encoding.cpp
@@ -63,7 +54,7 @@ target_link_libraries(viamrealsense
         realsense2::realsense2
         libjpeg-turbo::turbojpeg-static
         CURL::libcurl
-        $<IF:$<TARGET_EXISTS:libzip::zip>,libzip::zip,PkgConfig::LIBZIP>
+        libzip::zip
     PRIVATE
         ${CMAKE_DL_LIBS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,12 @@ find_package(viam-cpp-sdk REQUIRED)
 find_package(libjpeg-turbo CONFIG REQUIRED)
 find_package(CURL REQUIRED)
 
-# Prefer Conan-provided libzip (via CMAKE_PREFIX_PATH) over system cmake configs,
-# which may reference missing files on some distros. Fall back to pkg-config.
-find_package(libzip QUIET NO_CMAKE_SYSTEM_PATH)
-if(NOT libzip_FOUND)
+# Conan 2.x always names its toolchain "conan_toolchain.cmake". Use that to
+# distinguish Conan builds (where find_package finds Conan's static libzip)
+# from native builds (where the system cmake config for libzip may be broken).
+if(CMAKE_TOOLCHAIN_FILE MATCHES "conan_toolchain")
+    find_package(libzip REQUIRED)
+else()
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(LIBZIP REQUIRED IMPORTED_TARGET libzip)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,14 @@ find_package(realsense2 REQUIRED)
 find_package(viam-cpp-sdk REQUIRED)
 find_package(libjpeg-turbo CONFIG REQUIRED)
 find_package(CURL REQUIRED)
-find_package(libzip REQUIRED)
+
+# Prefer Conan-provided libzip (via CMAKE_PREFIX_PATH) over system cmake configs,
+# which may reference missing files on some distros. Fall back to pkg-config.
+find_package(libzip QUIET NO_CMAKE_SYSTEM_PATH)
+if(NOT libzip_FOUND)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LIBZIP REQUIRED IMPORTED_TARGET libzip)
+endif()
 
 add_library(viamrealsense
     src/module/encoding.cpp
@@ -54,7 +61,7 @@ target_link_libraries(viamrealsense
         realsense2::realsense2
         libjpeg-turbo::turbojpeg-static
         CURL::libcurl
-        libzip::zip
+        $<IF:$<TARGET_EXISTS:libzip::zip>,libzip::zip,PkgConfig::LIBZIP>
     PRIVATE
         ${CMAKE_DL_LIBS}
 )

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,7 +21,8 @@ class ViamRealsense(ConanFile):
     options = {"with_tests": [True, False]}
     default_options = {
         "with_tests": False,
-        "viam-cpp-sdk/*:shared": False
+        "viam-cpp-sdk/*:shared": False,
+        "libzip/*:shared": False
     }
 
     exports_sources = "CMakeLists.txt", "LICENSE", "src/*", "cmake/*", "meta.json", "test/*"


### PR DESCRIPTION
## Summary

- Removes the `pkg_check_modules` / pkg-config path for libzip from `CMakeLists.txt` — always use Conan's `find_package(libzip REQUIRED)` and link statically against `libzip::zip`
- Adds `"libzip/*:shared": False` to `conanfile.py` default options to ensure the Conan-provided libzip is built and linked statically
- Replaces buildjet for GH runners, as for some reason buildjet is not working, its runners never run
- Uploads build artifacts (module.tar.gz) on each PR, no just on each release, this helps test that our CI built modules work OK

## Why

On a fresh Raspberry Pi OS install, `libzip.so.4` is not present. The previous `CMakeLists.txt` preferred the system libzip via pkg-config, which baked in a dynamic `libzip.so.4` dependency at build time even though Conan's libzip was available. This caused the module to fail to start on any machine missing libzip at runtime.

## Test plan

- [x] Build `module.tar.gz` for `linux/arm64` and verify `ldd viam-camera-realsense | grep zip` returns nothing
- [x] Confirm firmware update works (this is the workflow that uses zip to unzip the firmware file)
- [x] Downloaded this module from CI and verified it works OK on amd64, darwin and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)