### PR TITLE
[RSDK-13785] Bump librealsense to 2.57.7 for kernel 6.12 support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -37,10 +37,7 @@ class ViamRealsense(ConanFile):
 
     def requirements(self):
         self.requires("viam-cpp-sdk/0.31.0")
-        if self.settings.os == "Macos":
-            self.requires("librealsense/2.57.6")
-        else:
-            self.requires("librealsense/2.56.5")
+        self.requires("librealsense/2.57.7")
         self.requires("libjpeg-turbo/[>=2.1.0 <3]")
         self.requires("libcurl/[>=8.0.0 <9]")
         self.requires("libzip/1.11.1")

--- a/etc/Dockerfile.cuda.debian.bookworm
+++ b/etc/Dockerfile.cuda.debian.bookworm
@@ -84,7 +84,7 @@ RUN apt install -y libgtest-dev
 RUN mkdir -p /root/opt/src
 
 # install librealsense from source
-ENV REALSENSE_VERSION="v2.56.5"
+ENV REALSENSE_VERSION="v2.57.7"
 RUN cd /root/opt/src && \
     git clone https://github.com/IntelRealSense/librealsense.git && \
     cd librealsense && \

--- a/etc/Dockerfile.debian.bookworm
+++ b/etc/Dockerfile.debian.bookworm
@@ -79,7 +79,7 @@ RUN apt install -y libgtest-dev
 RUN mkdir -p /root/opt/src
 
 # Install librealsense from source
-ENV REALSENSE_VERSION="v2.56.5"
+ENV REALSENSE_VERSION="v2.57.7"
 RUN cd /root/opt/src && \
     git clone https://github.com/IntelRealSense/librealsense.git && \
     cd librealsense && \


### PR DESCRIPTION
## Summary

- Bumps librealsense from `2.56.5` / `2.57.6` (platform-split) to a single unified `2.57.7` in `conanfile.py`
- Updates `Dockerfile.debian.bookworm` and `Dockerfile.cuda.debian.bookworm` to `v2.57.7`

## Why

librealsense 2.56.5 does not support Linux kernel 6.12, which ships with recent Raspberry Pi OS on the Pi 5. Attempting to open the camera produces a `bad optional access` crash inside librealsense. Version 2.57.7 supports kernel 6.12.

The previous `conanfile.py` used a platform split (2.57.6 on macOS, 2.56.5 elsewhere) — this removes the split and uses 2.57.7 everywhere. The Conan package for 2.57.7 is published to the `viamconan` JFrog registry for `linux/arm64`, `linux/amd64`, and `macOS`.

## Notes

- librealsense 2.57.7 is labeled "Beta" by Intel but is focused on stability; it is currently the only version with kernel 6.12 support
- As part of this work I also added a new Conan recipe for version 2.57.7,  where I had to includes patches for GCC 12/13 missing includes (`<cstring>`, `<algorithm>`, `<stdexcept>`)
- I was a good samaritan and [created a PR](https://github.com/realsenseai/librealsense/pull/14944) for those includes in librealsense upstream, which was accepted and merged

## Test plan

- [x] Build `module.tar.gz` for `linux/arm64` — confirm successful build with librealsense 2.57.7
- [x] Confirm camera works on Raspberry Pi 5 (kernel 6.12) — no `bad optional access` crash
- [x] Confirm camera works on `linux/amd64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)