### PR TITLE
[RSDK-13787] Fix camera not resuming after firmware is already up to date

### DIFF
--- a/src/module/firmware_update.hpp
+++ b/src/module/firmware_update.hpp
@@ -274,27 +274,6 @@ updateFirmware(std::shared_ptr<rs2::device> rs_device,
              "firmware version: "
           << recommended_version;
 
-      // Pre-flight check: Compare current firmware version with recommended
-      if (rs_device->supports(RS2_CAMERA_INFO_FIRMWARE_VERSION)) {
-        std::string current_version =
-            rs_device->get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
-        VIAM_SDK_LOG_IMPL(logger, info)
-            << "[handleFirmwareUpdate] Current firmware version: "
-            << current_version;
-
-        if (current_version == recommended_version) {
-          std::string msg =
-              std::string("Firmware is already at the recommended version (") +
-              current_version +
-              "). No update needed. To force an update to a specific version, "
-              "specify the firmware URL directly using: {\"update_firmware\": "
-              "\"https://your-firmware-url.zip\"}. Find firmware URLs at: "
-              "https://dev.realsenseai.com/docs/firmware-releases-d400";
-          VIAM_SDK_LOG_IMPL(logger, info) << "[handleFirmwareUpdate] " << msg;
-          return {true, {{"message", msg}, {"no_update_needed", "true"}}};
-        }
-      }
-
       // Look up URL for recommended version
       auto const firmware_url_opt =
           getFirmwareURLForVersion(recommended_version);

--- a/src/module/firmware_update.hpp
+++ b/src/module/firmware_update.hpp
@@ -291,7 +291,7 @@ updateFirmware(std::shared_ptr<rs2::device> rs_device,
               "\"https://your-firmware-url.zip\"}. Find firmware URLs at: "
               "https://dev.realsenseai.com/docs/firmware-releases-d400";
           VIAM_SDK_LOG_IMPL(logger, info) << "[handleFirmwareUpdate] " << msg;
-          return {true, {{"message", msg}}};
+          return {true, {{"message", msg}, {"no_update_needed", "true"}}};
         }
       }
 

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -1004,8 +1004,8 @@ private:
           return response;
         }
 
-        // If no firmware URL was provided, check whether the device already runs
-        // the recommended version before stopping the stream
+        // If no firmware URL was provided, check whether the device already
+        // runs the recommended version before stopping the stream
         if (firmware_url.empty()) {
           auto device_guard = device_->synchronize();
           auto pre_check_device = device_guard->device;

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -1037,18 +1037,29 @@ private:
 
       // Check if firmware update succeeded
       if (update_result.first) {
-        // Success - clear device assignment
-        device_ = nullptr;
-        recovery_device_ptr_ = nullptr;
-        physical_camera_assigned_ = false;
-        is_recovery_mode_ = false;
+        bool no_update_needed = update_result.second.count("no_update_needed");
+        if (no_update_needed) {
+          // No update was performed — device was stopped but not flashed.
+          // Restart it so streaming resumes.
+          VIAM_RESOURCE_LOG(info)
+              << "[handleFirmwareUpdate] No update needed, restarting device";
+          device_funcs_.startDevice(device_serial_number, device_,
+                                    latest_frameset_, MAX_FRAME_AGE_MS,
+                                    config_, this->logger_);
+        } else {
+          // Firmware was flashed — device will reboot and reconnect on its own.
+          device_ = nullptr;
+          recovery_device_ptr_ = nullptr;
+          physical_camera_assigned_ = false;
+          is_recovery_mode_ = false;
 
-        // Remove the device's serial number from the assigned set
-        // This allows the device to be reassigned when it reconnects after
-        // firmware update
-        {
-          auto serials_guard = assigned_serials_->synchronize();
-          serials_guard->erase(device_serial_number);
+          // Remove the device's serial number from the assigned set
+          // This allows the device to be reassigned when it reconnects after
+          // firmware update
+          {
+            auto serials_guard = assigned_serials_->synchronize();
+            serials_guard->erase(device_serial_number);
+          }
         }
 
         response["success"] = true;

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -963,6 +963,37 @@ private:
 
     try {
 
+      // If not in recovery mode and no firmware URL was provided, check whether
+      // the device already runs the recommended version before touching any
+      // state — no callback clearing, no stream disruption needed.
+      if (!is_recovery_mode_.get() && firmware_url.empty() && device_) {
+        auto device_guard = device_->synchronize();
+        auto pre_check_device = device_guard->device;
+        std::string current, recommended;
+        if (pre_check_device &&
+            device_funcs_.getFirmwareVersions(pre_check_device, current,
+                                              recommended)) {
+          VIAM_RESOURCE_LOG(info)
+              << "[handleFirmwareUpdate] Current firmware: " << current
+              << ", recommended: " << recommended;
+          if (current == recommended) {
+            std::string msg =
+                std::string(
+                    "Firmware is already at the recommended version (") +
+                current +
+                "). No update needed. To force an update to a specific "
+                "version, specify the firmware URL directly using: "
+                "{\"update_firmware\": \"https://your-firmware-url.zip\"}. "
+                "Find firmware URLs at: "
+                "https://dev.realsenseai.com/docs/firmware-releases-d400";
+            VIAM_RESOURCE_LOG(info) << "[handleFirmwareUpdate] " << msg;
+            response["success"] = true;
+            response["message"] = msg;
+            return response;
+          }
+        }
+      }
+
       // Temporarily clear the device change callback to prevent interference
       // It will be automatically restored when this scope exits
       realsense_ctx_->clearDevicesChangedCallback();
@@ -1005,36 +1036,6 @@ private:
           VIAM_RESOURCE_LOG(error) << "[handleFirmwareUpdate] Firmware update "
                                       "failed: No device available";
           return response;
-        }
-
-        // If no firmware URL was provided, check whether the device already
-        // runs the recommended version before stopping the stream
-        if (firmware_url.empty()) {
-          auto device_guard = device_->synchronize();
-          auto pre_check_device = device_guard->device;
-          std::string current, recommended;
-          if (pre_check_device &&
-              device_funcs_.getFirmwareVersions(pre_check_device, current,
-                                                recommended)) {
-            VIAM_RESOURCE_LOG(info)
-                << "[handleFirmwareUpdate] Current firmware: " << current
-                << ", recommended: " << recommended;
-            if (current == recommended) {
-              std::string msg =
-                  std::string(
-                      "Firmware is already at the recommended version (") +
-                  current +
-                  "). No update needed. To force an update to a specific "
-                  "version, specify the firmware URL directly using: "
-                  "{\"update_firmware\": \"https://your-firmware-url.zip\"}. "
-                  "Find firmware URLs at: "
-                  "https://dev.realsenseai.com/docs/firmware-releases-d400";
-              VIAM_RESOURCE_LOG(info) << "[handleFirmwareUpdate] " << msg;
-              response["success"] = true;
-              response["message"] = msg;
-              return response;
-            }
-          }
         }
 
         // Stop the device before firmware update

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -1045,7 +1045,7 @@ private:
               << "[handleFirmwareUpdate] No update needed, restarting device";
           device_funcs_.startDevice(device_serial_number, device_,
                                     latest_frameset_, MAX_FRAME_AGE_MS,
-                                    config_, this->logger_);
+                                    config_.get(), this->logger_);
         } else {
           // Firmware was flashed — device will reboot and reconnect on its own.
           device_ = nullptr;

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -182,6 +182,9 @@ struct DeviceFunctions {
       std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>> &,
       realsense::RsResourceConfig const &, viam::sdk::LogSource &)>
       reconfigureDevice;
+  std::function<bool(std::shared_ptr<rs2::device>, std::string &current,
+                     std::string &recommended)>
+      getFirmwareVersions;
 };
 
 template <typename SynchronizedContextT>
@@ -1009,14 +1012,10 @@ private:
         if (firmware_url.empty()) {
           auto device_guard = device_->synchronize();
           auto pre_check_device = device_guard->device;
+          std::string current, recommended;
           if (pre_check_device &&
-              pre_check_device->supports(
-                  RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION) &&
-              pre_check_device->supports(RS2_CAMERA_INFO_FIRMWARE_VERSION)) {
-            std::string recommended = pre_check_device->get_info(
-                RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION);
-            std::string current =
-                pre_check_device->get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
+              device_funcs_.getFirmwareVersions(pre_check_device, current,
+                                                recommended)) {
             VIAM_RESOURCE_LOG(info)
                 << "[handleFirmwareUpdate] Current firmware: " << current
                 << ", recommended: " << recommended;
@@ -1387,6 +1386,20 @@ private:
                   rs2::device, rs2::config, rs2::color_sensor,
                   rs2::depth_sensor, rs2::video_stream_profile>(
                   device, viamConfig, logger);
+            },
+        .getFirmwareVersions =
+            [](std::shared_ptr<rs2::device> dev, std::string &current,
+               std::string &recommended) -> bool {
+              if (!dev ||
+                  !dev->supports(RS2_CAMERA_INFO_FIRMWARE_VERSION) ||
+                  !dev->supports(
+                      RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION)) {
+                return false;
+              }
+              current = dev->get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
+              recommended = dev->get_info(
+                  RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION);
+              return true;
             }};
   };
 };

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -1004,7 +1004,8 @@ private:
           return response;
         }
 
-        // In auto-detect mode, check firmware version before disrupting streaming
+        // If no firmware URL was provided, check whether the device already runs
+        // the recommended version before stopping the stream
         if (firmware_url.empty()) {
           auto device_guard = device_->synchronize();
           auto pre_check_device = device_guard->device;

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -970,9 +970,8 @@ private:
         auto device_guard = device_->synchronize();
         auto pre_check_device = device_guard->device;
         std::string current, recommended;
-        if (pre_check_device &&
-            device_funcs_.getFirmwareVersions(pre_check_device, current,
-                                              recommended)) {
+        if (pre_check_device && device_funcs_.getFirmwareVersions(
+                                    pre_check_device, current, recommended)) {
           VIAM_RESOURCE_LOG(info)
               << "[handleFirmwareUpdate] Current firmware: " << current
               << ", recommended: " << recommended;
@@ -1388,20 +1387,18 @@ private:
                   rs2::depth_sensor, rs2::video_stream_profile>(
                   device, viamConfig, logger);
             },
-        .getFirmwareVersions =
-            [](std::shared_ptr<rs2::device> dev, std::string &current,
-               std::string &recommended) -> bool {
-              if (!dev ||
-                  !dev->supports(RS2_CAMERA_INFO_FIRMWARE_VERSION) ||
-                  !dev->supports(
-                      RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION)) {
-                return false;
-              }
-              current = dev->get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
-              recommended = dev->get_info(
-                  RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION);
-              return true;
-            }};
+        .getFirmwareVersions = [](std::shared_ptr<rs2::device> dev,
+                                  std::string &current,
+                                  std::string &recommended) -> bool {
+          if (!dev || !dev->supports(RS2_CAMERA_INFO_FIRMWARE_VERSION) ||
+              !dev->supports(RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION)) {
+            return false;
+          }
+          current = dev->get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
+          recommended =
+              dev->get_info(RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION);
+          return true;
+        }};
   };
 };
 }; // namespace realsense

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -1004,6 +1004,39 @@ private:
           return response;
         }
 
+        // In auto-detect mode, check firmware version before disrupting streaming
+        if (firmware_url.empty()) {
+          auto device_guard = device_->synchronize();
+          auto pre_check_device = device_guard->device;
+          if (pre_check_device &&
+              pre_check_device->supports(
+                  RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION) &&
+              pre_check_device->supports(RS2_CAMERA_INFO_FIRMWARE_VERSION)) {
+            std::string recommended = pre_check_device->get_info(
+                RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION);
+            std::string current =
+                pre_check_device->get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
+            VIAM_RESOURCE_LOG(info)
+                << "[handleFirmwareUpdate] Current firmware: " << current
+                << ", recommended: " << recommended;
+            if (current == recommended) {
+              std::string msg =
+                  std::string(
+                      "Firmware is already at the recommended version (") +
+                  current +
+                  "). No update needed. To force an update to a specific "
+                  "version, specify the firmware URL directly using: "
+                  "{\"update_firmware\": \"https://your-firmware-url.zip\"}. "
+                  "Find firmware URLs at: "
+                  "https://dev.realsenseai.com/docs/firmware-releases-d400";
+              VIAM_RESOURCE_LOG(info) << "[handleFirmwareUpdate] " << msg;
+              response["success"] = true;
+              response["message"] = msg;
+              return response;
+            }
+          }
+        }
+
         // Stop the device before firmware update
         VIAM_RESOURCE_LOG(info)
             << "[handleFirmwareUpdate] Stopping device before update";
@@ -1037,29 +1070,15 @@ private:
 
       // Check if firmware update succeeded
       if (update_result.first) {
-        bool no_update_needed = update_result.second.count("no_update_needed");
-        if (no_update_needed) {
-          // No update was performed — device was stopped but not flashed.
-          // Restart it so streaming resumes.
-          VIAM_RESOURCE_LOG(info)
-              << "[handleFirmwareUpdate] No update needed, restarting device";
-          device_funcs_.startDevice(device_serial_number, device_,
-                                    latest_frameset_, MAX_FRAME_AGE_MS,
-                                    config_.get(), this->logger_);
-        } else {
-          // Firmware was flashed — device will reboot and reconnect on its own.
-          device_ = nullptr;
-          recovery_device_ptr_ = nullptr;
-          physical_camera_assigned_ = false;
-          is_recovery_mode_ = false;
+        // Firmware was flashed — device will reboot and reconnect on its own.
+        device_ = nullptr;
+        recovery_device_ptr_ = nullptr;
+        physical_camera_assigned_ = false;
+        is_recovery_mode_ = false;
 
-          // Remove the device's serial number from the assigned set
-          // This allows the device to be reassigned when it reconnects after
-          // firmware update
-          {
-            auto serials_guard = assigned_serials_->synchronize();
-            serials_guard->erase(device_serial_number);
-          }
+        {
+          auto serials_guard = assigned_serials_->synchronize();
+          serials_guard->erase(device_serial_number);
         }
 
         response["success"] = true;

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -970,8 +970,8 @@ private:
         auto device_guard = device_->synchronize();
         auto pre_check_device = device_guard->device;
         std::string current, recommended;
-        if (pre_check_device && device_funcs_.getFirmwareVersions(
-                                    pre_check_device, current, recommended)) {
+        if (device_funcs_.getFirmwareVersions(pre_check_device, current,
+                                              recommended)) {
           VIAM_RESOURCE_LOG(info)
               << "[handleFirmwareUpdate] Current firmware: " << current
               << ", recommended: " << recommended;

--- a/test/realsense_tests.cpp
+++ b/test/realsense_tests.cpp
@@ -687,9 +687,9 @@ TEST_F(RealsenseTest,
 #else
   EXPECT_FALSE(stop_device_called);
   EXPECT_TRUE(*result["success"].get<bool>());
-  auto msg_opt = result["message"].get<std::string>();
-  ASSERT_TRUE(msg_opt.has_value());
-  EXPECT_TRUE(msg_opt->find("already at the recommended version") !=
+  auto msg_ptr = result["message"].get<std::string>();
+  ASSERT_NE(msg_ptr, nullptr);
+  EXPECT_TRUE(msg_ptr->find("already at the recommended version") !=
               std::string::npos);
 #endif
 }

--- a/test/realsense_tests.cpp
+++ b/test/realsense_tests.cpp
@@ -682,11 +682,18 @@ TEST_F(RealsenseTest,
   command["update_firmware"] = "";
   auto result = camera.do_command(command);
 
+#ifdef __APPLE__
+  EXPECT_FALSE(*result["success"].get<bool>());
+  auto error = *result["error"].get<std::string>();
+  EXPECT_TRUE(error.find("not supported on macOS") != std::string::npos);
+#else
   EXPECT_FALSE(stop_device_called);
   EXPECT_TRUE(*result["success"].get<bool>());
-  auto msg = *result["message"].get<std::string>();
-  EXPECT_TRUE(msg.find("already at the recommended version") !=
+  auto msg_opt = result["message"].get<std::string>();
+  ASSERT_TRUE(msg_opt.has_value());
+  EXPECT_TRUE(msg_opt->find("already at the recommended version") !=
               std::string::npos);
+#endif
 }
 
 TEST_F(RealsenseTest, FirmwareUpdate_AutoDetect_Outdated_StopsDevice) {
@@ -721,8 +728,14 @@ TEST_F(RealsenseTest, FirmwareUpdate_AutoDetect_Outdated_StopsDevice) {
   command["update_firmware"] = "";
   auto result = camera.do_command(command);
 
+#ifdef __APPLE__
+  EXPECT_FALSE(*result["success"].get<bool>());
+  auto error = *result["error"].get<std::string>();
+  EXPECT_TRUE(error.find("not supported on macOS") != std::string::npos);
+#else
   EXPECT_TRUE(stop_device_called);
   EXPECT_FALSE(*result["success"].get<bool>());
+#endif
 }
 
 int main(int argc, char **argv) {

--- a/test/realsense_tests.cpp
+++ b/test/realsense_tests.cpp
@@ -84,8 +84,7 @@ public:
        realsense::RsResourceConfig const &),
       ());
   MOCK_METHOD(bool, getFirmwareVersions,
-              (std::shared_ptr<rs2::device>, std::string &, std::string &),
-              ());
+              (std::shared_ptr<rs2::device>, std::string &, std::string &), ());
 };
 
 DeviceFunctions
@@ -142,11 +141,11 @@ createMockDeviceFunctionsWithOrder(std::shared_ptr<MockDeviceFunctions> mock) {
               viam::sdk::LogSource &) {
             mock->reconfigureDevice(device, viamConfig);
           },
-      .getFirmwareVersions =
-          [mock](std::shared_ptr<rs2::device> dev, std::string &current,
-                 std::string &recommended) -> bool {
-            return mock->getFirmwareVersions(dev, current, recommended);
-          }};
+      .getFirmwareVersions = [mock](std::shared_ptr<rs2::device> dev,
+                                    std::string &current,
+                                    std::string &recommended) -> bool {
+        return mock->getFirmwareVersions(dev, current, recommended);
+      }};
 }
 
 DeviceFunctions createFullyMockedDeviceFunctions() {
@@ -217,12 +216,11 @@ DeviceFunctions createFullyMockedDeviceFunctions() {
              viam::sdk::LogSource &) {
             std::cout << "Mock: reconfigureDevice called" << std::endl;
           },
-      .getFirmwareVersions =
-          [](std::shared_ptr<rs2::device>, std::string &,
-             std::string &) -> bool {
-            // Default: report no version info available
-            return false;
-          }};
+      .getFirmwareVersions = [](std::shared_ptr<rs2::device>, std::string &,
+                                std::string &) -> bool {
+        // Default: report no version info available
+        return false;
+      }};
 }
 
 class SimpleMockContext {
@@ -666,9 +664,9 @@ TEST_F(RealsenseTest,
     }
     return true;
   };
-  device_funcs.getFirmwareVersions =
-      [](std::shared_ptr<rs2::device>, std::string &current,
-         std::string &recommended) -> bool {
+  device_funcs.getFirmwareVersions = [](std::shared_ptr<rs2::device>,
+                                        std::string &current,
+                                        std::string &recommended) -> bool {
     current = "5.16.0.1";
     recommended = "5.16.0.1"; // Same — no update needed
     return true;
@@ -712,9 +710,9 @@ TEST_F(RealsenseTest, FirmwareUpdate_AutoDetect_Outdated_StopsDevice) {
     }
     return true;
   };
-  device_funcs.getFirmwareVersions =
-      [](std::shared_ptr<rs2::device>, std::string &current,
-         std::string &recommended) -> bool {
+  device_funcs.getFirmwareVersions = [](std::shared_ptr<rs2::device>,
+                                        std::string &current,
+                                        std::string &recommended) -> bool {
     current = "5.15.0.0";
     recommended = "5.16.0.1"; // Different — update needed
     return true;

--- a/test/realsense_tests.cpp
+++ b/test/realsense_tests.cpp
@@ -83,6 +83,9 @@ public:
       (std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>> &,
        realsense::RsResourceConfig const &),
       ());
+  MOCK_METHOD(bool, getFirmwareVersions,
+              (std::shared_ptr<rs2::device>, std::string &, std::string &),
+              ());
 };
 
 DeviceFunctions
@@ -138,6 +141,11 @@ createMockDeviceFunctionsWithOrder(std::shared_ptr<MockDeviceFunctions> mock) {
               realsense::RsResourceConfig const &viamConfig,
               viam::sdk::LogSource &) {
             mock->reconfigureDevice(device, viamConfig);
+          },
+      .getFirmwareVersions =
+          [mock](std::shared_ptr<rs2::device> dev, std::string &current,
+                 std::string &recommended) -> bool {
+            return mock->getFirmwareVersions(dev, current, recommended);
           }};
 }
 
@@ -208,7 +216,12 @@ DeviceFunctions createFullyMockedDeviceFunctions() {
              realsense::RsResourceConfig const &viamConfig,
              viam::sdk::LogSource &) {
             std::cout << "Mock: reconfigureDevice called" << std::endl;
-            // No-op for mock
+          },
+      .getFirmwareVersions =
+          [](std::shared_ptr<rs2::device>, std::string &,
+             std::string &) -> bool {
+            // Default: report no version info available
+            return false;
           }};
 }
 
@@ -634,6 +647,82 @@ TEST_F(RealsenseTest, ReconfigureWithNewSerialNumber_StrictOrdering) {
       Model("viam", "camera", "realsense"), LinkConfig{}, log_level::info);
 
   EXPECT_NO_THROW({ camera.reconfigure(test_deps_, new_config); });
+}
+
+TEST_F(RealsenseTest,
+       FirmwareUpdate_AutoDetect_AlreadyCurrent_DoesNotStopDevice) {
+  bool stop_device_called = false;
+
+  auto device_funcs = createFullyMockedDeviceFunctions();
+  device_funcs.stopDevice =
+      [&stop_device_called](
+          std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>>
+              &device,
+          viam::sdk::LogSource &) -> bool {
+    stop_device_called = true;
+    if (device) {
+      auto locked = device->synchronize();
+      locked->started = false;
+    }
+    return true;
+  };
+  device_funcs.getFirmwareVersions =
+      [](std::shared_ptr<rs2::device>, std::string &current,
+         std::string &recommended) -> bool {
+    current = "5.16.0.1";
+    recommended = "5.16.0.1"; // Same — no update needed
+    return true;
+  };
+
+  Realsense<boost::synchronized_value<SimpleMockContext>> camera(
+      test_deps_, *test_config_, mock_realsense_context_, device_funcs,
+      assigned_serials_);
+
+  ProtoStruct command;
+  command["update_firmware"] = "";
+  auto result = camera.do_command(command);
+
+  EXPECT_FALSE(stop_device_called);
+  EXPECT_TRUE(*result["success"].get<bool>());
+  auto msg = *result["message"].get<std::string>();
+  EXPECT_TRUE(msg.find("already at the recommended version") !=
+              std::string::npos);
+}
+
+TEST_F(RealsenseTest, FirmwareUpdate_AutoDetect_Outdated_StopsDevice) {
+  bool stop_device_called = false;
+
+  auto device_funcs = createFullyMockedDeviceFunctions();
+  device_funcs.stopDevice =
+      [&stop_device_called](
+          std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>>
+              &device,
+          viam::sdk::LogSource &) -> bool {
+    stop_device_called = true;
+    if (device) {
+      auto locked = device->synchronize();
+      locked->started = false;
+    }
+    return true;
+  };
+  device_funcs.getFirmwareVersions =
+      [](std::shared_ptr<rs2::device>, std::string &current,
+         std::string &recommended) -> bool {
+    current = "5.15.0.0";
+    recommended = "5.16.0.1"; // Different — update needed
+    return true;
+  };
+
+  Realsense<boost::synchronized_value<SimpleMockContext>> camera(
+      test_deps_, *test_config_, mock_realsense_context_, device_funcs,
+      assigned_serials_);
+
+  ProtoStruct command;
+  command["update_firmware"] = "";
+  auto result = camera.do_command(command);
+
+  EXPECT_TRUE(stop_device_called);
+  EXPECT_FALSE(*result["success"].get<bool>());
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Summary:

When do_command({"update_firmware": ""}) is called, it excercises the auto-detect flow in which we detect the current firmware of the device and its recommended one and if they differ and we have stored the URL of the recommended firmware, we download it and install it.  

The current issue is that if they are the same, i.e. the camera is already at its recommended firmware, we stop its streaming anyways and don't recover unless the camera is re-plugged.

The dis consists on that In auto-detect mode we now check the current and recommended firmware versions before touching any device state. If they match, return a success response immediately instead of stopping the streaming.

Also, adding unit tests to cover update_firmware

## Test plan:

- [x] Call do_command({"update_firmware": ""}) on a camera already running the recommended firmware version
- [x] Verify the command returns successfully with the "already at recommended version" message
- [x] Verify the camera resumes streaming immediately after without requiring a module restart