### PR TITLE
RSDK-13954 - Use bookworm for reload builds

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -24,7 +24,8 @@
     "arch": [
       "linux/amd64",
       "linux/arm64"
-    ]
+    ],
+    "distro": "bookworm"
   },
   "entrypoint": "viam-camera-realsense",
   "first_run": "./first_run.sh"


### PR DESCRIPTION
## Description
Add `"distro": "bookworm"` to `meta.json` so cloud module reload/build requests pin to a Bookworm builder image instead of Bullseye.

Currently, cloud builder via reload falls back to an older Debian image (glibc 2.31), where ConanCenter's current `boost/1.91.0` recipe fails to build (it is bootstrapped `b2` binary requires glibc ≥ 2.32/2.33/2.34).

Pinning to bookworm aligns the cloud builder with the local dev image already defined in `etc/Dockerfile.debian.bookworm`.

## Testing
- [x] Verify `viam module reload` succeeds against the bookworm builder

```
viam module reload --part-id=<part-id>
 …  Preparing for build...
 ✓     → Source code archive created (0s)                                                                                                                                             
 ✓     → Source code uploaded (2s)                                                                                                                                                    
 ✓  Prepared for build (2s)
 …  Building...
 ✓     → Build started (ID: e67184a8-c83a-41a5-82d6-f42756142b00) (3s)                                                                                                                
 ✓     → Spin up environment (30s)                                                                                                                                                    
 ✓     → Install Viam CLI (2s)                                                                                                                                                        
 ✓     → Install dependencies (2s)                                                                                                                                                    
 ✓     → Build module (50m10s)                                                                                                                                                        
 ✓     → Uploading artifacts (10s)                                                                                                                                                    
 ✓  Built (50m57s)
 …  Reloading to part...
 ✓     → Module added to part (0s)                                                                                                                                                    
 ✓  Reloaded to part (0s)
```