### PR TITLE
Pin clang format for darwin

### DIFF
--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -27,7 +27,8 @@ else
     if [[ "$(uname)" == "Linux" ]]; then
         sudo apt update && sudo apt install -y clang-format-19
     elif [[ "$(uname)" == "Darwin" ]]; then
-        brew install clang-format
+        brew install llvm@19
+        export PATH="$(brew --prefix llvm@19)/bin:$PATH"
     else
         echo "WARNING: installing the linter is not yet supported outside of Linux and Mac."
     fi


### PR DESCRIPTION
## Description
Macos CI test runs have been [failing recently](https://github.com/viam-modules/viam-camera-realsense/actions/runs/25692921215/job/75433748217). Simple fix to pin to an older clang-format version to match up with linux environments.

## Testing

[Successful ci run](https://github.com/viam-modules/viam-camera-realsense/actions/runs/25750417554/job/75624934765?pr=146)
