### PR TITLE
fix(get_geometries): correct camera bounding-box geometry and anchor to color sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ The following methods of the Viam camera API are supported:
 
 #### Frame origin and `extrinsic_parameters`
 
-The RealSense D4xx series has multiple imagers at slightly different positions on the device. The **camera frame origin is anchored at the depth left imager** — the same convention used by the bounding-box geometries returned by `get_geometries`.
+The RealSense D4xx series has multiple imagers at slightly different positions on the device. The **camera frame origin is anchored at the depth left imager** for `extrinsic_parameters`.
+
+> **Note:** the bounding-box geometries returned by `get_geometries` are anchored at the **color (RGB) sensor**, not the depth left imager, since `get_properties` reports color intrinsics and the poses callers derive from the images are in the color frame. This differs from the `extrinsic_parameters` reference frame described below, and from the `GetPointCloud` output (which is in the depth frame). If you compose geometries and point clouds in the same frame, account for the ~14.7 mm (D435/D435i) color→depth baseline.
 
 `get_properties` returns color intrinsics whenever `color` is configured (depth intrinsics otherwise), regardless of `sensors` list order. `extrinsic_parameters` is always the transform from the intrinsics sensor's frame to the depth left imager (the camera reference frame). With the default `["color", "depth"]` config this is the color→depth transform; when only depth is configured — or only one sensor is configured — extrinsics are identity (zero translation).
 

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -819,10 +819,6 @@ public:
     if (model && (*model == "D415")) {
       // D415: 99 (w) x 23 (h) x 20 (d) mm. Z = 20/2 - 1.1 = 8.9 mm.
       // X = 20 (centerline->left imager) + color->depth baseline.
-      // TODO: the D415 color->depth baseline is not a datasheet constant (it is
-      // per-device calibration, and the D415 module differs from the D435).
-      // ~15 mm is an estimate; replace with the calibrated value when
-      // available.
       return {viam::sdk::GeometryConfig(viam::sdk::pose{35, 0, -8.9},
                                         viam::sdk::box({99, 23, 20}), "box")};
     }

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -781,9 +781,26 @@ public:
   get_geometries(const viam::sdk::ProtoStruct &extra) override {
     // Geometries are model-specific. The pose is the offset from the camera
     // reference origin (depth left imager) to the center of the bounding box,
-    // and the box dimensions match the physical module size in mm. See
-    // https://github.com/viam-modules/viam-camera-realsense/pull/75 for the
-    // derivation of the D435/D435i values.
+    // and the box dimensions {x, y, z} match the physical module size in mm.
+    // The camera optical frame is +X right, +Y down, +Z forward (out of the
+    // lens), so x = width, y = height, z = depth.
+    //
+    // Values are derived from the Intel RealSense D400-Series Datasheet
+    // (337029-005):
+    //   - Module dimensions: Table 3-43 (D415), Table 3-44 (D435/D435i).
+    //   - X offset (centerline of 1/4-20 mount to left imager): Table 4-15
+    //     (17.5 mm for D435/D435i, 20 mm for D415). The mount is on the module
+    //     centerline (the box center), so the left imager is this distance off
+    //     center. It is on the -X side: the right imager is one stereo baseline
+    //     (50 mm) further along +X, which would fall off the module edge if the
+    //     left imager were on the +X side. The offset from the origin (left
+    //     imager) to the box center is therefore +X (positive).
+    //   - Z offset: the depth origin (depth start point) sits behind the front
+    //     cover glass per Table 4-13 (4.2 mm for D435/D435i, 1.1 mm for D415).
+    //     The glass is the front face of the box, so the box center is
+    //     depth/2 behind the glass, i.e. (depth/2 - recession) behind the
+    //     origin. The left imager is on the housing's horizontal centerline
+    //     (Figure 4-6), so y = 0.
     // NOTE: when adding support for additional RealSense camera models,
     // update this switch accordingly.
     std::optional<std::string> model;
@@ -794,14 +811,13 @@ public:
       }
     }
     if (model && (*model == "D415")) {
-      // D415 module dimensions per Intel datasheet: 99 x 20 x 23 mm.
-      // The depth left imager sits near the left edge of the front face,
-      // mirroring the D435 layout offset by the difference in module size.
-      return {viam::sdk::GeometryConfig(viam::sdk::pose{-22, 0, -11.5},
-                                        viam::sdk::box({99, 20, 23}), "box")};
+      // D415: 99 (w) x 23 (h) x 20 (d) mm. Z = 20/2 - 1.1 = 8.9 mm.
+      return {viam::sdk::GeometryConfig(viam::sdk::pose{20, 0, -8.9},
+                                        viam::sdk::box({99, 23, 20}), "box")};
     }
     // Default: D435 / D435i geometry.
-    return {viam::sdk::GeometryConfig(viam::sdk::pose{-17.5, 0, -12.5},
+    // D435: 90 (w) x 25 (h) x 25 (d) mm. Z = 25/2 - 4.2 = 8.3 mm.
+    return {viam::sdk::GeometryConfig(viam::sdk::pose{17.5, 0, -8.3},
                                       viam::sdk::box({90, 25, 25}), "box")};
   }
 

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -821,7 +821,8 @@ public:
       // X = 20 (centerline->left imager) + color->depth baseline.
       // TODO: the D415 color->depth baseline is not a datasheet constant (it is
       // per-device calibration, and the D415 module differs from the D435).
-      // ~15 mm is an estimate; replace with the calibrated value when available.
+      // ~15 mm is an estimate; replace with the calibrated value when
+      // available.
       return {viam::sdk::GeometryConfig(viam::sdk::pose{35, 0, -8.9},
                                         viam::sdk::box({99, 23, 20}), "box")};
     }

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -780,27 +780,33 @@ public:
   std::vector<viam::sdk::GeometryConfig>
   get_geometries(const viam::sdk::ProtoStruct &extra) override {
     // Geometries are model-specific. The pose is the offset from the camera
-    // reference origin (depth left imager) to the center of the bounding box,
-    // and the box dimensions {x, y, z} match the physical module size in mm.
-    // The camera optical frame is +X right, +Y down, +Z forward (out of the
-    // lens), so x = width, y = height, z = depth.
+    // reference origin (the RGB/color sensor) to the center of the bounding
+    // box, and the box dimensions {x, y, z} match the physical module size in
+    // mm. The camera optical frame is +X right, +Y down, +Z forward (out of
+    // the lens), so x = width, y = height, z = depth.
     //
-    // Values are derived from the Intel RealSense D400-Series Datasheet
-    // (337029-005):
+    // The origin is the color sensor because get_properties reports color
+    // intrinsics and the images/derived poses callers work with are in the
+    // color frame. Box dimensions and the depth-imager placement come from the
+    // Intel RealSense D400-Series Datasheet (337029-005); the color sensor's
+    // position is then derived from the color->depth extrinsics.
     //   - Module dimensions: Table 3-43 (D415), Table 3-44 (D435/D435i).
-    //   - X offset (centerline of 1/4-20 mount to left imager): Table 4-15
-    //     (17.5 mm for D435/D435i, 20 mm for D415). The mount is on the module
-    //     centerline (the box center), so the left imager is this distance off
-    //     center. It is on the -X side: the right imager is one stereo baseline
-    //     (50 mm) further along +X, which would fall off the module edge if the
-    //     left imager were on the +X side. The offset from the origin (left
-    //     imager) to the box center is therefore +X (positive).
-    //   - Z offset: the depth origin (depth start point) sits behind the front
-    //     cover glass per Table 4-13 (4.2 mm for D435/D435i, 1.1 mm for D415).
-    //     The glass is the front face of the box, so the box center is
-    //     depth/2 behind the glass, i.e. (depth/2 - recession) behind the
-    //     origin. The left imager is on the housing's horizontal centerline
-    //     (Figure 4-6), so y = 0.
+    //   - The depth left imager is offset from the module centerline (the box
+    //     center) per Table 4-15 (17.5 mm for D435/D435i, 20 mm for D415), on
+    //     the -X side: the right imager is one stereo baseline (50 mm D435,
+    //     55 mm D415) further along +X, which would fall off the module edge
+    //     if the left imager were on the +X side.
+    //   - The color sensor sits a further ~14.7 mm along -X from the depth left
+    //     imager for D435/D435i (color->depth extrinsics ~= {-14.7, 0, 0} mm),
+    //     so it is ~32.2 mm in -X from the box center, with no Y/Z component.
+    //     The offset from the origin (color sensor) to the box center is
+    //     therefore +X (positive): +32.2 mm for D435/D435i.
+    //   - Z offset: the color sensor shares the depth origin's Z plane, which
+    //     sits behind the front cover glass per Table 4-13 (4.2 mm for
+    //     D435/D435i, 1.1 mm for D415). The glass is the front face of the box,
+    //     so the box center is (depth/2 - recession) behind the origin. The
+    //     imagers are on the housing's horizontal centerline (Figure 4-6), and
+    //     the color->depth extrinsics have no Y component, so y = 0.
     // NOTE: when adding support for additional RealSense camera models,
     // update this switch accordingly.
     std::optional<std::string> model;
@@ -812,12 +818,17 @@ public:
     }
     if (model && (*model == "D415")) {
       // D415: 99 (w) x 23 (h) x 20 (d) mm. Z = 20/2 - 1.1 = 8.9 mm.
-      return {viam::sdk::GeometryConfig(viam::sdk::pose{20, 0, -8.9},
+      // X = 20 (centerline->left imager) + color->depth baseline.
+      // TODO: the D415 color->depth baseline is not a datasheet constant (it is
+      // per-device calibration, and the D415 module differs from the D435).
+      // ~15 mm is an estimate; replace with the calibrated value when available.
+      return {viam::sdk::GeometryConfig(viam::sdk::pose{35, 0, -8.9},
                                         viam::sdk::box({99, 23, 20}), "box")};
     }
     // Default: D435 / D435i geometry.
     // D435: 90 (w) x 25 (h) x 25 (d) mm. Z = 25/2 - 4.2 = 8.3 mm.
-    return {viam::sdk::GeometryConfig(viam::sdk::pose{17.5, 0, -8.3},
+    // X = 17.5 (centerline->left imager) + 14.7 (color->depth baseline) = 32.2.
+    return {viam::sdk::GeometryConfig(viam::sdk::pose{32.2, 0, -8.3},
                                       viam::sdk::box({90, 25, 25}), "box")};
   }
 

--- a/test/realsense_tests.cpp
+++ b/test/realsense_tests.cpp
@@ -506,7 +506,7 @@ TEST_F(RealsenseTest, GetGeometriesReturnsExpectedGeometry) {
   EXPECT_EQ(geometries.size(), 1);
   EXPECT_EQ(geometries,
             std::vector<viam::sdk::GeometryConfig>{viam::sdk::GeometryConfig(
-                viam::sdk::pose{17.5, 0, -8.3}, viam::sdk::box({90, 25, 25}),
+                viam::sdk::pose{32.2, 0, -8.3}, viam::sdk::box({90, 25, 25}),
                 "box")});
 }
 

--- a/test/realsense_tests.cpp
+++ b/test/realsense_tests.cpp
@@ -506,7 +506,7 @@ TEST_F(RealsenseTest, GetGeometriesReturnsExpectedGeometry) {
   EXPECT_EQ(geometries.size(), 1);
   EXPECT_EQ(geometries,
             std::vector<viam::sdk::GeometryConfig>{viam::sdk::GeometryConfig(
-                viam::sdk::pose{-17.5, 0, -12.5}, viam::sdk::box({90, 25, 25}),
+                viam::sdk::pose{17.5, 0, -8.3}, viam::sdk::box({90, 25, 25}),
                 "box")});
 }
 


### PR DESCRIPTION
## Summary

The bounding boxes returned by `get_geometries` did not match the physical RealSense modules, so the camera collision geometry was mis-placed in the frame system (most significantly mirrored to the wrong side along X by ~35 mm). This corrects all geometry values from the Intel RealSense D400-Series Datasheet (337029-005) and re-anchors the geometry reference origin to the **RGB/color sensor** so it matches the frame callers actually work in (`get_properties` reports color intrinsics, and image-derived poses are in the color frame).

## Changes

- **src/module/realsense.hpp (`get_geometries`)**: Recomputed the per-model bounding boxes with the full datasheet derivation documented in comments.
  - **X offset sign**: the depth left imager is on the **−X** side of the module center (forced by the stereo geometry — the right imager is one baseline along +X and would fall off the module edge otherwise), so the origin→box-center offset is **+X**. The previous negative values placed the box on the wrong side.
  - **Origin re-anchored to the color sensor**: shifts X by the color→depth baseline (~14.7 mm for D435/D435i), no Y/Z change since the color sensor shares the depth origin's Y/Z plane.
  - **D415 box dimensions**: height and depth were swapped (`{99, 20, 23}` → `{99, 23, 20}`); per Table 3-43 the D415 is 99 (w) × 23 (h) × 20 (d) mm.
  - **Z offset**: account for the depth origin sitting behind the front cover glass (Table 4-13: 4.2 mm D435/D435i, 1.1 mm D415), so the box is no longer shifted ~4 mm too far back.
- **test/realsense_tests.cpp**: Updated `GetGeometriesReturnsExpectedGeometry` to the new D435 expectation.
- **README.md**: Documented that `get_geometries` is now color-anchored, which diverges from the `extrinsic_parameters` reference frame and `GetPointCloud` (both depth-anchored).

Resulting geometries (`pose`, `box`):
- D435/D435i: `pose{32.2, 0, -8.3}`, `box{90, 25, 25}`
- D415: `pose{35, 0, -8.9}`, `box{99, 23, 20}`

## Reviewer notes / open items

- **D415 X offset (35 mm) is an estimate.** The D415 color→depth baseline is per-device calibration, not a datasheet constant, and the D415 module differs from the D435; ~15 mm is a placeholder, marked with a `TODO`. The D435/D435i value (32.2) is solid.
- **Frame divergence is intentional but worth a deliberate sign-off.** Geometry is now color-anchored while `extrinsic_parameters` (PR #141) and `GetPointCloud` remain depth-anchored — composing the box and a point cloud in one frame will be off by the ~14.7 mm baseline. Documented in the README.

## Testing

- Updated unit test `GetGeometriesReturnsExpectedGeometry` (covers the default D435 path).
- Recommended: `make conan-build-test` to confirm compilation and that the geometry test passes.
- Recommended manual check: configure a D435/D435i (and D415 if available) in the frame system and confirm the box wraps the physical housing.


<img width="1589" height="944" alt="image" src="https://github.com/user-attachments/assets/7fa79e33-e6af-4c04-ac09-54065cdd6275" />
Before the change, for a camera which has been frame calibrated, we can the camera on the right which is not centered on the arm, contrary to the physical reality


<img width="942" height="577" alt="image" src="https://github.com/user-attachments/assets/c449ac9f-e20c-4f06-b1fa-be2e8c79e476" />
Using this change, a frame calibrated camera has its geometry properly centered

## Tickets

None

## Claude Code Prompts Used

- "I have noticed that the camera geometry is incorrect. The frame we use for the camera is at the RGB sensor... Can you look into that and if the geometry indeed seems incorrect propose a fix?"
- "The X translation seems incorrect. Either the sign is wrong or we are using the offset to the depth sensor instead of using the offset to the RGB sensor"
- "Can you commit, push, and create a draft PR?"
- "If we assume that the camera reference origin is aligned with the RGB sensor, what would the geometry configs look like?"
- "apply the RGB anchored config to the branch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)