### PR TITLE
ci(test): share Conan cache with build-publish and raise timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   run-tests:
     name: Run Tests
-    timeout-minutes: 10
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -38,6 +38,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      # Same path/key as build-publish.yml so the two workflows share Conan
+      # caches (macos-latest collides; Linux legs keep their own namespace).
+      - name: Restore cached libraries
+        uses: actions/cache@v3
+        with:
+          path: ~/.conan2
+          key: ${{ matrix.os }}-conan-${{ hashFiles('**/conanfile.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-conan-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

`test.yml` had **no Conan caching**, so the `macos-latest` leg rebuilt all heavy deps (grpc, protobuf, openssl, re2) from source on every run. That pushed it past the 10-minute `timeout-minutes`, and with the matrix default `fail-fast`, the timeout cancelled the sibling Linux legs too — masking their actual pass/fail (this is what cancelled the recent `main` runs).

## Changes

- **Reuse `build-publish.yml`'s Conan cache.** Add a `Restore cached libraries` step with the *identical* `~/.conan2` path and `${{ matrix.os }}-conan-${{ hashFiles('**/conanfile.py') }}` key. GitHub matches caches by key across workflows in the same repo, so:
  - `macos-latest` collides between both workflows → the macOS cache is genuinely **shared** (no separate cache created).
  - The Linux legs use different os names / container images, so they keep their own cache namespace — which is correct (don't mix Conan binaries across base images).
  - `restore-keys` gives partial hits when `conanfile.py` changes, so only the changed dep rebuilds.
- **Raise `timeout-minutes` 10 → 30.** A cold macOS build must complete once to actually *save* the cache; at 10m it was cancelled before the save, so the cache could never warm up.

`fail-fast` is intentionally left at the default per review feedback.

## Notes

- Uses `actions/cache@v3` to match `build-publish.yml`'s existing style. SHA-pinning all actions is a separate repo-wide cleanup.