### PR TITLE
ci(build): run build-publish on push to main to seed Conan cache

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,6 +14,11 @@ on:
         default: main
         description: realsense module branch to run on
   pull_request:
+  # Build on main (no artifact upload / publish) to seed a main-scoped Conan
+  # cache that PR and release runs can restore.
+  push:
+    branches:
+      - main
 
 
 permissions:


### PR DESCRIPTION
## Why

GitHub Actions caches are **branch-scoped**: a PR can only restore caches created on its own branch or on **`main`**. `build-publish.yml` only triggered on PRs/releases, so it **never created a `main`-scoped cache**. Combined with it building heavy deps from source on Linux (`ubuntu:22.04`/gcc 11 isn't prebuilt in viamconan), every PR paid the full ~17-min cold build — branch caches from other PRs are invisible.

## Change

Add `push: branches: [main]` to build-publish's triggers. On a `main` push the **build job** runs and **saves a `main`-scoped Conan cache** that all future PR/release runs can restore.

It does **not** publish or upload anything: the artifact-upload step (`if: event_name == 'release' || 'pull_request'`) and the registry-upload job (`if: event_name == 'release'`) are gated on `github.event_name`, which is `push` here — so both are skipped. A main push only builds + caches.

## Note

This mirrors what `test.yml` already does (it runs on `main` and seeds its own cache). The durable fix for the Linux *slowness* is still publishing gcc-11 binaries to viamconan; this just stops every PR from starting cold.