### PR TITLE
Replace defunct buildjet runners with GitHub-hosted runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: ubuntu-latest
             make_target: docker-amd64-ci
-          - os: buildjet-16vcpu-ubuntu-2204-arm
+          - os: github-linux-arm64-8core
             make_target: docker-arm64-ci
 
     steps:


### PR DESCRIPTION
The buildjet runners no longer work, breaking these workflows. This maps them to GitHub-hosted runners, matching the fix already made in [viamrobotics/rust-utils#178](https://github.com/viamrobotics/rust-utils/pull/178):

- `buildjet-*-ubuntu-2204-arm` (native arm64 builds) → `github-linux-arm64-8core`
- `buildjet-*-ubuntu-2204` (x86) → `ubuntu-large`

The amd64/arm64 build matrices and container images are otherwise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)