### PR TITLE
fix(pointcloud): drop redundant depth-frame check in PointCloudFilter

### DIFF
--- a/src/module/device.hpp
+++ b/src/module/device.hpp
@@ -26,10 +26,11 @@ public:
     // librealsense frame/align/pointcloud objects that cannot be constructed or
     // driven without hardware, so it is unreachable in the (camera-less) CI
     // test suite and is excluded from coverage. Validated on-device via the
-    // alignment probe instead. LCOV_EXCL_START The sole caller (get_point_cloud)
-    // already validates the depth frame, so we only check the color stream here
-    // to surface a helpful message (align_to_color_->process below would
-    // otherwise throw a generic error when the color stream is missing).
+    // alignment probe instead. LCOV_EXCL_START The sole caller
+    // (get_point_cloud) already validates the depth frame, so we only check the
+    // color stream here to surface a helpful message (align_to_color_->process
+    // below would otherwise throw a generic error when the color stream is
+    // missing).
     if (!frameset.get_color_frame()) {
       throw std::runtime_error(
           "No color frame in frameset — point clouds require both color and "

--- a/src/module/device.hpp
+++ b/src/module/device.hpp
@@ -26,13 +26,10 @@ public:
     // librealsense frame/align/pointcloud objects that cannot be constructed or
     // driven without hardware, so it is unreachable in the (camera-less) CI
     // test suite and is excluded from coverage. Validated on-device via the
-    // alignment probe instead. LCOV_EXCL_START Validate both streams are
-    // present first so we can surface a helpful message
-    // (align_to_color_->process below would otherwise throw a generic error
-    // when the color stream is missing).
-    if (!frameset.get_depth_frame()) {
-      throw std::runtime_error("No depth frame in frameset");
-    }
+    // alignment probe instead. LCOV_EXCL_START The sole caller (get_point_cloud)
+    // already validates the depth frame, so we only check the color stream here
+    // to surface a helpful message (align_to_color_->process below would
+    // otherwise throw a generic error when the color stream is missing).
     if (!frameset.get_color_frame()) {
       throw std::runtime_error(
           "No color frame in frameset — point clouds require both color and "


### PR DESCRIPTION
## Summary

Addresses review feedback on #161. `PointCloudFilter::process` opened with a depth-frame existence check, but the sole caller — `get_point_cloud` — already validates the depth frame (and throws a helpful error) before `process` is ever reached, so the internal check was redundant duplication with a strictly-less-useful message.

The color-frame check stays: `align_to_color_->process` would otherwise throw a generic error when color is missing, and its diagnostic message (about USB bandwidth / sensor config) is not surfaced by the caller.

- `src/module/device.hpp` — remove the redundant depth-frame check; update the accompanying comment.

## Test Plan

- [x] `make test` — 146/146 unit tests pass, module compiles.

The `process` body remains `LCOV_EXCL`'d (it can only run against live hardware), so there is no coverage change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)