### PR TITLE
Make frameset simple synchronized_value

### DIFF
--- a/src/module/device.hpp
+++ b/src/module/device.hpp
@@ -90,10 +90,9 @@ void deviceChangedCallback(
     std::uint64_t maxFrameAgeMs);
 
 template <typename FrameT, typename FrameSetT, typename ViamConfigT>
-void frameCallback(
-    FrameT const &frame, std::uint64_t const maxFrameAgeMs,
-    boost::synchronized_value<std::shared_ptr<FrameSetT>> &frame_set_,
-    ViamConfigT const &viamConfig);
+void frameCallback(FrameT const &frame, std::uint64_t const maxFrameAgeMs,
+                   boost::synchronized_value<FrameSetT> &frame_set_,
+                   ViamConfigT const &viamConfig);
 
 /********************** DEVICE LIFECYCLE ************************/
 template <typename ViamConfigT, typename ViamDeviceT = ViamRSDevice<>,
@@ -112,11 +111,11 @@ bool destroyDevice(
 
 /********************** STREAMING LIFECYCLE ************************/
 template <typename ViamDeviceT, typename FrameSetT, typename ViamConfigT>
-void startDevice(
-    std::string const &serialNumber,
-    std::shared_ptr<boost::synchronized_value<ViamDeviceT>> dev,
-    std::shared_ptr<boost::synchronized_value<FrameSetT>> &frame_set_storage,
-    std::uint64_t const maxFrameAgeMs, ViamConfigT const &viamConfig);
+void startDevice(std::string const &serialNumber,
+                 std::shared_ptr<boost::synchronized_value<ViamDeviceT>> dev,
+                 boost::synchronized_value<FrameSetT> &frame_set_storage,
+                 std::uint64_t const maxFrameAgeMs,
+                 ViamConfigT const &viamConfig);
 
 template <typename ViamDeviceT>
 bool stopDevice(

--- a/src/module/device_impl.hpp
+++ b/src/module/device_impl.hpp
@@ -313,10 +313,9 @@ void printDeviceInfo(DeviceT const &dev, viam::sdk::LogSource &logger) {
 /********************** CALLBACKS ************************/
 
 template <typename FrameT, typename FrameSetT, typename ViamConfigT>
-void frameCallback(
-    FrameT const &frame, std::uint64_t const maxFrameAgeMs,
-    std::shared_ptr<boost::synchronized_value<FrameSetT>> &frame_set_,
-    ViamConfigT const &viamConfig) {
+void frameCallback(FrameT const &frame, std::uint64_t const maxFrameAgeMs,
+                   boost::synchronized_value<FrameSetT> &frame_set_,
+                   ViamConfigT const &viamConfig) {
   // With callbacks, all synchronized stream will arrive in a single
   // frameset
   int expected_frame_count = viamConfig.sensors.size();
@@ -376,7 +375,9 @@ void frameCallback(
     }
   }
 
-  frame_set_ = std::make_shared<boost::synchronized_value<FrameSetT>>(frameset);
+  // Publish under the synchronized_value's lock; get_images/get_point_cloud/
+  // watchdog read it concurrently through the same lock.
+  frame_set_ = frameset;
 }
 
 /************************ STREAM PROFILES ************************/
@@ -699,12 +700,11 @@ createDevice(std::string const &serial_number, std::shared_ptr<DeviceT> dev,
 
 /********************** STREAMING LIFECYCLE ************************/
 template <typename ViamDeviceT, typename FrameSetT, typename ViamConfigT>
-void startDevice(
-    std::string const &serialNumber,
-    std::shared_ptr<boost::synchronized_value<ViamDeviceT>> dev,
-    std::shared_ptr<boost::synchronized_value<FrameSetT>> &frameSetStorage,
-    std::uint64_t const maxFrameAgeMs, ViamConfigT const &viamConfig,
-    viam::sdk::LogSource &logger) {
+void startDevice(std::string const &serialNumber,
+                 std::shared_ptr<boost::synchronized_value<ViamDeviceT>> dev,
+                 boost::synchronized_value<FrameSetT> &frameSetStorage,
+                 std::uint64_t const maxFrameAgeMs,
+                 ViamConfigT const &viamConfig, viam::sdk::LogSource &logger) {
   VIAM_DEVICE_LOG(logger, info)
       << "[startDevice] starting device " << serialNumber;
   if (not dev) {

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -208,9 +208,8 @@ struct DeviceFunctions {
   std::function<void(
       std::string const &,
       std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>> &,
-      std::shared_ptr<boost::synchronized_value<rs2::frameset>> &,
-      std::uint64_t, realsense::RsResourceConfig const &,
-      viam::sdk::LogSource &)>
+      boost::synchronized_value<rs2::frameset> &, std::uint64_t,
+      realsense::RsResourceConfig const &, viam::sdk::LogSource &)>
       startDevice;
   std::function<bool(std::shared_ptr<rs2::device>, std::string &current,
                      std::string &recommended)>
@@ -578,13 +577,15 @@ public:
         }
       }
 
-      if (not latest_frameset_) {
+      // get() copies the frameset under the synchronized_value's lock, so it
+      // is race-free wrt frameCallback's locked assignment.
+      auto fs = latest_frameset_.get();
+      if (not fs) {
         VIAM_RESOURCE_LOG(error) << "[get_images] no frameset available";
         throw std::runtime_error("no frameset available");
       }
       VIAM_RESOURCE_LOG(debug) << "[get_images] start";
       std::string serial_number = config_->serial_number;
-      auto fs = latest_frameset_->get();
 
       // Optionally align depth to color so that depth_np[v, u] and
       // color_np[v, u] refer to the same physical point. The IR/depth and
@@ -711,12 +712,14 @@ public:
         VIAM_RESOURCE_LOG(error) << "[get_point_cloud] " << error_msg;
         throw std::runtime_error(error_msg);
       }
-      if (not latest_frameset_) {
+      // get() copies the frameset under the synchronized_value's lock, so it
+      // is race-free wrt frameCallback's locked assignment.
+      auto fs = latest_frameset_.get();
+      if (not fs) {
         VIAM_RESOURCE_LOG(error) << "[get_point_cloud] no frameset available";
         throw std::runtime_error("no frameset available");
       }
       VIAM_RESOURCE_LOG(debug) << "[get_point_cloud] start";
-      auto fs = latest_frameset_->get();
 
       double nowMs = time::getNowMs();
 
@@ -1188,12 +1191,10 @@ public:
       }
     };
     auto recovery_check = [this]() { return is_recovery_mode_.get(); };
-    // Read latest_frameset_ on every poll — captures `this` so we always
-    // see the freshest shared_ptr value Realsense holds (frameCallback
-    // reassigns the pointer per frame). Empty frameset when none yet.
-    auto get_fs = [this]() -> rs2::frameset {
-      return latest_frameset_ ? latest_frameset_->get() : rs2::frameset{};
-    };
+    // Read latest_frameset_ on every poll. get() copies under the
+    // synchronized_value's lock (race-free wrt frameCallback); returns an
+    // empty frameset until the first frame arrives.
+    auto get_fs = [this]() -> rs2::frameset { return latest_frameset_.get(); };
     watchdog_ = std::make_unique<watchdog::StaleFrameWatchdog<rs2::frameset>>(
         std::move(get_fs), std::move(recovery_check), std::move(restart_fn),
         this->logger_);
@@ -1204,7 +1205,7 @@ public:
 private:
   boost::synchronized_value<RsResourceConfig> config_;
   std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>> device_;
-  std::shared_ptr<boost::synchronized_value<rs2::frameset>> latest_frameset_;
+  boost::synchronized_value<rs2::frameset> latest_frameset_;
   std::shared_ptr<boost::synchronized_value<std::unordered_set<std::string>>>
       assigned_serials_;
   boost::synchronized_value<bool> physical_camera_assigned_;
@@ -1714,8 +1715,7 @@ private:
             [](const std::string &serial,
                std::shared_ptr<
                    boost::synchronized_value<device::ViamRSDevice<>>> &device,
-               std::shared_ptr<boost::synchronized_value<rs2::frameset>>
-                   &latest_frameset,
+               boost::synchronized_value<rs2::frameset> &latest_frameset,
                std::uint64_t maxFrameSetFrameMs,
                realsense::RsResourceConfig const &viamConfig,
                viam::sdk::LogSource &logger) {

--- a/test/realsense_tests.cpp
+++ b/test/realsense_tests.cpp
@@ -75,8 +75,8 @@ public:
       void, startDevice,
       (const std::string &,
        std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>> &,
-       std::shared_ptr<boost::synchronized_value<rs2::frameset>> &,
-       std::uint64_t, const realsense::RsResourceConfig &),
+       boost::synchronized_value<rs2::frameset> &, std::uint64_t,
+       const realsense::RsResourceConfig &),
       ());
   MOCK_METHOD(bool, getFirmwareVersions,
               (std::shared_ptr<rs2::device>, std::string &, std::string &), ());
@@ -120,8 +120,7 @@ createMockDeviceFunctionsWithOrder(std::shared_ptr<MockDeviceFunctions> mock) {
               const std::string &serial,
               std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>>
                   &device,
-              std::shared_ptr<boost::synchronized_value<rs2::frameset>>
-                  &latest_frameset,
+              boost::synchronized_value<rs2::frameset> &latest_frameset,
               std::uint64_t maxFrameAgeMs,
               const realsense::RsResourceConfig &viamConfig,
               viam::sdk::LogSource &) {
@@ -185,8 +184,7 @@ DeviceFunctions createFullyMockedDeviceFunctions() {
           [](const std::string &serial,
              std::shared_ptr<boost::synchronized_value<device::ViamRSDevice<>>>
                  &device,
-             std::shared_ptr<boost::synchronized_value<rs2::frameset>>
-                 &latest_frameset,
+             boost::synchronized_value<rs2::frameset> &latest_frameset,
              std::uint64_t maxFrameAgeMs,
              const realsense::RsResourceConfig &viamConfig,
              viam::sdk::LogSource &) {


### PR DESCRIPTION
## Description

There has been an existing race vulnerability between frame callback writer and readers
(get_images, get_point_cloud, and the watchdog loop)

The steady watchdog poll at 1hz surfaced:
```
[module/watchdog.hpp:114] [watchdog] poll error: out of range value for argument "index"
```

latest_frameset_ was a std::shared_ptr<synchronized_value<rs2::frameset>> 

the inner synchronized_value was not working as intended - the whole object was being
replaced via the frame callback, so a reader locked the old mutex while the writer installed a new one

Furthermore, the shared_ptr use seems like it was unnecessary -  rs2::frameset is already a refcounted (does not perform any expensive data copy operations). See class [here](https://github.com/realsenseai/librealsense/blob/fec2d156e531f417c927262818f3440cfbcde4e9/include/librealsense2/hpp/rs_frame.hpp#L1066) and ref increment [here](https://github.com/IntelRealSense/librealsense/blob/fec2d156e531f417c927262818f3440cfbcde4e9/include/librealsense2/hpp/rs_frame.hpp#L411-L419).

## Tests
- [x] long running manual test on amd64 machine to sanity check
- [x] try out on the problematic machine

## Corollary
- [x] figure out why we were not seeing this issue surfaced through standard get_images use

It likely did, invisibly:

librealsense recycles composites from a pool of identically-shaped (color+depth) frames, so a stale handle usually still "works", callers just silently got a recycled frameset. On the rare shape mismatch it threw, `get_images` returned a one-off RPC error that clients retried past.


