### PR TITLE
Add D405 camera support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ The following methods of the Viam camera API are supported:
 
 The RealSense D4xx series has multiple imagers at slightly different positions on the device. The **camera frame origin is anchored at the depth left imager** for `extrinsic_parameters`.
 
-> **Note:** the bounding-box geometries returned by `get_geometries` are anchored at the **color (RGB) sensor**, not the depth left imager, since `get_properties` reports color intrinsics and the poses callers derive from the images are in the color frame. This differs from the `extrinsic_parameters` reference frame described below, and from the `GetPointCloud` output (which is in the depth frame). If you compose geometries and point clouds in the same frame, account for the ~14.7 mm (D435/D435i) color→depth baseline.
+> **Note:** the bounding-box geometries returned by `get_geometries` are anchored at the **color (RGB) sensor**, not the depth left imager, since `get_properties` reports color intrinsics and the poses callers derive from the images are in the color frame. This differs from the `extrinsic_parameters` reference frame described below, and from the `GetPointCloud` output (which is in the depth frame). If you compose geometries and point clouds in the same frame, account for the ~14.7 mm (D435/D435i) color→depth baseline. The D405 has no dedicated RGB sensor — its color stream comes from the depth left imager — so on that model the color and depth frames share an origin and the baseline is ~0.
 
 `get_properties` returns color intrinsics whenever `color` is configured (depth intrinsics otherwise), regardless of `sensors` list order. `extrinsic_parameters` is always the transform from the intrinsics sensor's frame to the depth left imager (the camera reference frame). With the default `["color", "depth"]` config this is the color→depth transform; when only depth is configured — or only one sensor is configured — extrinsics are identity (zero translation).
 
 | Field | Contents |
 | ----- | -------- |
 | `intrinsic_parameters` | `fx`, `fy`, `ppx`, `ppy` for the color sensor when configured, otherwise depth. |
-| `extrinsic_parameters.translation` | Transform from the intrinsics sensor's frame to the depth left imager (camera reference frame), in millimeters. Approximately `{-14.7, 0, 0}` mm for D435/D435i when color is configured (color→depth direction); identity when only depth is configured. |
+| `extrinsic_parameters.translation` | Transform from the intrinsics sensor's frame to the depth left imager (camera reference frame), in millimeters. Approximately `{-14.7, 0, 0}` mm for D435/D435i when color is configured (color→depth direction); ~identity on the D405 (color is served by the left imager); identity when only depth is configured. |
 | `extrinsic_parameters.orientation` | Identity — the sub-degree rotation between depth and color is treated as zero. |
 
 With the default config (`["color", "depth"]`), if you derive a pose from color-stream intrinsics (e.g. an AprilTag detector or any PnP solver), the resulting pose is in the **color sensor frame**. To express it in the camera reference frame — which is what Viam composes against other components and the world frame — add `extrinsic_parameters.translation`:
@@ -378,14 +378,16 @@ Or, if you aren't using the Viam app to manage your machine's configuration, mod
 
 Support for specific hardware is known for the following devices. The table is not complete and subject to change.
 
-| Devices               | D415 | D435 | D435i | D455 |
-|-----------------------|------|------|-------|------|
-| RPi 4B/5 Trixie       |      |  X   |   X   |      |
-| RPi 4B/5 Bookworm     |      |  X   |   X   |      |
-| RPi 4B Bullseye       |      |  X   |       |      |
-| Orin Nano JetPack 5.1 |      |  X   |   X   |  X   |
-| UP 4000               |      |  X   |       |      |
-| macOS                 |      |      |  (1)  |      |
+| Devices               | D405 | D415 | D435 | D435i | D455 |
+|-----------------------|------|------|------|-------|------|
+| RPi 4B/5 Trixie       |      |      |  X   |   X   |      |
+| RPi 4B/5 Bookworm     |      |      |  X   |   X   |      |
+| RPi 4B Bullseye       |      |      |  X   |       |      |
+| Orin Nano JetPack 5.1 |      |      |  X   |   X   |  X   |
+| UP 4000               |      |      |  X   |       |      |
+| macOS                 |      |      |      |  (1)  |      |
+
+D405 support is implemented (the module accounts for its single-sensor design, where the color stream is served by the depth left imager, and its 0.1 mm default depth units) but has not yet been validated on the platforms above.
 
 (1) macOS support is experimental and based on [v2.57.6 (Beta)](https://github.com/realsenseai/librealsense/releases/tag/v2.57.6) from RealSense. May have stability issues. Firmware updates are not supported on macOS.
 

--- a/src/module/device_impl.hpp
+++ b/src/module/device_impl.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 
 #include <viam/sdk/log/logging.hpp>
@@ -141,40 +142,30 @@ void applyDepthSensorOptions(SensorT &sensor, ViamConfigT const &viamConfig,
   }
 }
 
+// Call this on the sensor that serves the color stream. On most D400
+// cameras that is the dedicated RGB sensor; on the D405 the stereo sensor
+// serves color itself, so callers gate on what the sensor serves rather
+// than on its extension type.
 template <typename SensorT>
 void disableAutoExposurePriority(SensorT &sensor,
                                  viam::sdk::LogSource &logger) {
-  try {
-    auto sensor_type = sensors::get_sensor_type(sensor, logger);
-    if (sensor_type == sensors::SensorType::unknown) {
-      throw std::runtime_error("Unknown sensor type");
+  // CRITICAL: Disable auto-exposure priority to maintain frame sync.
+  // When enabled, RGB sensor drops frames to adjust exposure, breaking
+  // temporal alignment with depth (causes 5-20ms timestamp drift).
+  // Tradeoff: slightly worse exposure in changing light conditions,
+  // but tight temporal sync (mostly <5ms) between color and depth.
+  if (sensor.supports(RS2_OPTION_AUTO_EXPOSURE_PRIORITY)) {
+    try {
+      // Disable auto-exposure priority to ensure constant FPS
+      sensor.set_option(RS2_OPTION_AUTO_EXPOSURE_PRIORITY, 0.0);
+      VIAM_DEVICE_LOG(logger, info)
+          << "[disableAutoExposurePriority] Disabled Auto-Exposure Priority "
+             "(constant FPS) for color sensor";
+    } catch (const std::exception &e) {
+      VIAM_DEVICE_LOG(logger, warn) << "[disableAutoExposurePriority] Failed "
+                                       "to disable Auto-Exposure Priority: "
+                                    << e.what();
     }
-    // Only disable auto-exposure priority for color sensors
-    if (sensor_type != sensors::SensorType::color) {
-      return;
-    }
-    // CRITICAL: Disable auto-exposure priority to maintain frame sync.
-    // When enabled, RGB sensor drops frames to adjust exposure, breaking
-    // temporal alignment with depth (causes 5-20ms timestamp drift).
-    // Tradeoff: slightly worse exposure in changing light conditions,
-    // but tight temporal sync (mostly <5ms) between color and depth.
-    if (sensor.supports(RS2_OPTION_AUTO_EXPOSURE_PRIORITY)) {
-      try {
-        // Disable auto-exposure priority to ensure constant FPS
-        sensor.set_option(RS2_OPTION_AUTO_EXPOSURE_PRIORITY, 0.0);
-        VIAM_DEVICE_LOG(logger, info)
-            << "[disableAutoExposurePriority] Disabled Auto-Exposure Priority "
-               "(constant FPS) for color sensor";
-      } catch (const std::exception &e) {
-        VIAM_DEVICE_LOG(logger, warn) << "[disableAutoExposurePriority] Failed "
-                                         "to disable Auto-Exposure Priority: "
-                                      << e.what();
-      }
-    }
-  } catch (const std::exception &e) {
-    VIAM_DEVICE_LOG(logger, error)
-        << "[disableAutoExposurePriority] Failed to get sensor type: "
-        << e.what();
   }
 }
 
@@ -427,45 +418,48 @@ createSingleSensorConfig(std::shared_ptr<DeviceT> dev,
   // Query all sensors for the device
   auto sensors = dev->query_sensors();
 
-  typename decltype(sensors)::value_type sensor;
+  // Select by stream format rather than by sensor extension type: on most
+  // D400 cameras color and depth come from dedicated sensors, but on the
+  // D405 the single stereo sensor serves both streams and does not cast to
+  // rs2::color_sensor.
   for (auto &s : sensors) {
-    if (s.template is<SensorT>()) {
-      sensor = s;
-      enableGlobalTimestamp(sensor, logger);
-      // depth-sensor-only single-stream path
-      if (s.template is<rs2::depth_sensor>()) {
-        applyDepthSensorOptions(sensor, viamConfig, logger);
+    auto profiles = s.get_stream_profiles();
+    bool sensor_serves_stream = false;
+    for (auto &cp : profiles) {
+      // Skip non-video profiles (e.g. motion streams on IMU-equipped
+      // models) — casting them to a video profile is invalid.
+      if (not cp.template is<VideoStreamProfileT>()) {
+        continue;
       }
-    }
-  }
+      auto csp = cp.template as<VideoStreamProfileT>();
+      if (csp.format() != SensorTypeTraits<SensorT>::format_type) {
+        continue;
+      }
+      if (not sensor_serves_stream) {
+        sensor_serves_stream = true;
+        enableGlobalTimestamp(s, logger);
+        // depth-sensor-only single-stream path
+        if (SensorTypeTraits<SensorT>::stream_type == RS2_STREAM_DEPTH) {
+          applyDepthSensorOptions(s, viamConfig, logger);
+        }
+        VIAM_DEVICE_LOG(logger, info)
+            << "[createSingleSensorConfig] Got sensor with " << profiles.size()
+            << " stream profiles, looking for matches";
+      }
 
-  VIAM_DEVICE_LOG(logger, info)
-      << "[createSingleSensorConfig] Got sensor, getting stream profiles";
-  // Get stream profiles
-  auto profiles = sensor.get_stream_profiles();
-
-  VIAM_DEVICE_LOG(logger, info)
-      << "[createSingleSensorConfig] Got " << profiles.size()
-      << " stream profiles, looking for matches";
-  // Find matching profiles
-  for (auto &cp : profiles) {
-    auto csp = cp.template as<VideoStreamProfileT>();
-    if (csp.format() != SensorTypeTraits<SensorT>::format_type) {
-      continue;
-    }
-
-    if ((not viamConfig.width) or
-        (viamConfig.width == csp.width()) and
-            (not viamConfig.height or (viamConfig.height == csp.height()))) {
-      VIAM_DEVICE_LOG(logger, info)
-          << "[createSingleSensorConfig] Found matching "
-             "stream profile, enabling";
-      cfg->enable_stream(SensorTypeTraits<SensorT>::stream_type,
-                         csp.stream_index(), csp.width(), csp.height(),
-                         csp.format(), csp.fps());
-      VIAM_DEVICE_LOG(logger, info)
-          << "[createSingleSensorConfig] enabled stream";
-      return cfg;
+      if ((not viamConfig.width) or
+          (viamConfig.width == csp.width()) and
+              (not viamConfig.height or (viamConfig.height == csp.height()))) {
+        VIAM_DEVICE_LOG(logger, info)
+            << "[createSingleSensorConfig] Found matching "
+               "stream profile, enabling";
+        cfg->enable_stream(SensorTypeTraits<SensorT>::stream_type,
+                           csp.stream_index(), csp.width(), csp.height(),
+                           csp.format(), csp.fps());
+        VIAM_DEVICE_LOG(logger, info)
+            << "[createSingleSensorConfig] enabled stream";
+        return cfg;
+      }
     }
   }
   return nullptr;
@@ -482,23 +476,42 @@ std::shared_ptr<ConfigT> createSwD2CAlignConfig(std::shared_ptr<DeviceT> dev,
   // Query all sensors for the device
   auto sensors = dev->query_sensors();
 
-  typename decltype(sensors)::value_type color_sensor;
-  typename decltype(sensors)::value_type depth_sensor;
+  // Collect color and depth profiles by stream format from every sensor
+  // rather than looking for a dedicated color sensor and a dedicated depth
+  // sensor: on the D405 the single stereo sensor serves both streams and
+  // does not cast to rs2::color_sensor.
+  using SensorVectorT = decltype(sensors);
+  using ProfileVectorT =
+      std::decay_t<decltype(std::declval<typename SensorVectorT::value_type>()
+                                .get_stream_profiles())>;
+  ProfileVectorT color_profiles;
+  ProfileVectorT depth_profiles;
   for (auto &s : sensors) {
     enableGlobalTimestamp(s, logger);
-    if (s.template is<ColorSensorT>()) {
-      color_sensor = s;
-      disableAutoExposurePriority(color_sensor, logger);
+    bool serves_color = false;
+    bool serves_depth = false;
+    for (auto &p : s.get_stream_profiles()) {
+      // Skip non-video profiles (e.g. motion streams on IMU-equipped
+      // models) — casting them to a video profile is invalid.
+      if (not p.template is<VideoStreamProfileT>()) {
+        continue;
+      }
+      auto vsp = p.template as<VideoStreamProfileT>();
+      if (vsp.format() == SensorTypeTraits<ColorSensorT>::format_type) {
+        color_profiles.push_back(p);
+        serves_color = true;
+      } else if (vsp.format() == SensorTypeTraits<DepthSensorT>::format_type) {
+        depth_profiles.push_back(p);
+        serves_depth = true;
+      }
     }
-    if (s.template is<DepthSensorT>()) {
-      depth_sensor = s;
-      applyDepthSensorOptions(depth_sensor, viamConfig, logger);
+    if (serves_color) {
+      disableAutoExposurePriority(s, logger);
+    }
+    if (serves_depth) {
+      applyDepthSensorOptions(s, viamConfig, logger);
     }
   }
-
-  // Get stream profiles
-  auto color_profiles = color_sensor.get_stream_profiles();
-  auto depth_profiles = depth_sensor.get_stream_profiles();
 
   // Find matching profiles
   for (auto &cp : color_profiles) {

--- a/src/module/encoding.cpp
+++ b/src/module/encoding.cpp
@@ -1,5 +1,9 @@
 #include "encoding.hpp"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include <turbojpeg.h>
 #include <viam/sdk/log/logging.hpp>
 
@@ -11,7 +15,8 @@ namespace encoding {
 
 std::vector<std::uint8_t> encodeDepthRAW(const std::uint8_t *data,
                                          const uint64_t width,
-                                         const uint64_t height) {
+                                         const uint64_t height,
+                                         const float mm_per_unit) {
   if (data == nullptr) {
     throw std::runtime_error("[encodeDepthRAW] data pointer is null");
   }
@@ -19,18 +24,31 @@ std::vector<std::uint8_t> encodeDepthRAW(const std::uint8_t *data,
   if (width == 0 || height == 0) {
     throw std::runtime_error("[encodeDepthRAW] invalid dimensions");
   }
+  if (mm_per_unit <= 0.0f) {
+    throw std::runtime_error("[encodeDepthRAW] invalid depth scale");
+  }
   viam::sdk::Camera::depth_map m =
       xt::xarray<uint16_t>::from_shape({height, width});
-  std::copy(reinterpret_cast<const uint16_t *>(data),
-            reinterpret_cast<const uint16_t *>(data) + height * width,
-            m.begin());
+  const uint16_t *src = reinterpret_cast<const uint16_t *>(data);
+  if (std::abs(mm_per_unit - 1.0f) < 1e-6f) {
+    std::copy(src, src + height * width, m.begin());
+  } else {
+    // Rescale raw depth units to millimeters, saturating at the uint16 max.
+    std::transform(
+        src, src + height * width, m.begin(), [mm_per_unit](uint16_t v) {
+          const long mm = std::lround(v * mm_per_unit);
+          return static_cast<uint16_t>(std::min(
+              mm, static_cast<long>(std::numeric_limits<uint16_t>::max())));
+        });
+  }
 
   return viam::sdk::Camera::encode_depth_map(m);
 }
 
 viam::sdk::Camera::raw_image encodeDepthRAWToResponse(const std::uint8_t *data,
                                                       const uint width,
-                                                      const uint height) {
+                                                      const uint height,
+                                                      const float mm_per_unit) {
   if (data == nullptr) {
     throw std::runtime_error("[encodeDepthRAWToResponse] data pointer is null");
   }
@@ -41,7 +59,7 @@ viam::sdk::Camera::raw_image encodeDepthRAWToResponse(const std::uint8_t *data,
   viam::sdk::Camera::raw_image response{};
   response.source_name = "depth";
   response.mime_type = "image/vnd.viam.dep";
-  response.bytes = encodeDepthRAW(data, width, height);
+  response.bytes = encodeDepthRAW(data, width, height, mm_per_unit);
   return response;
 }
 
@@ -126,8 +144,20 @@ encodeDepthFrameToResponse(rs2::depth_frame const &frame) {
     throw std::runtime_error("[encodeDepthFrameToResponse] frame profile is "
                              "not a video stream profile");
   }
+  // image/vnd.viam.dep values are millimeters. Most D400 cameras use 1 mm
+  // depth units so the raw values pass through unchanged, but the D405
+  // defaults to 0.1 mm units and must be rescaled.
+  float mm_per_unit = 1.0f;
+  try {
+    const float meters_per_unit = frame.get_units();
+    if (meters_per_unit > 0.0f) {
+      mm_per_unit = meters_per_unit * 1000.0f;
+    }
+  } catch (const std::exception &) {
+    // Fall back to 1 mm units if the device does not report depth units.
+  }
   return encodeDepthRAWToResponse(data, stream_profile.width(),
-                                  stream_profile.height());
+                                  stream_profile.height(), mm_per_unit);
 }
 
 struct PointXYZRGB {

--- a/src/module/encoding.hpp
+++ b/src/module/encoding.hpp
@@ -9,9 +9,12 @@
 namespace realsense {
 namespace encoding {
 
-viam::sdk::Camera::raw_image encodeDepthRAWToResponse(const std::uint8_t *data,
-                                                      const uint width,
-                                                      const uint height);
+// mm_per_unit converts raw depth values to millimeters (the unit of
+// image/vnd.viam.dep). Most D400 cameras use 1 mm depth units, but the D405
+// defaults to 0.1 mm units, so raw values must be rescaled.
+viam::sdk::Camera::raw_image
+encodeDepthRAWToResponse(const std::uint8_t *data, const uint width,
+                         const uint height, const float mm_per_unit = 1.0f);
 
 viam::sdk::Camera::raw_image encodeJPEGToResponse(const std::uint8_t *data,
                                                   const uint width,

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -28,7 +28,7 @@
 #include <boost/thread/synchronized_value.hpp>
 namespace realsense {
 static const std::unordered_set<std::string> SUPPORTED_CAMERA_MODELS = {
-    "D415", "D435", "D435I"};
+    "D405", "D415", "D435", "D435I"};
 static constexpr std::uint64_t MAX_FRAME_AGE_MS =
     1e3; // time until a frame is considered stale, in miliseconds (equal to 1
 static constexpr size_t MAX_GRPC_MESSAGE_SIZE =
@@ -947,6 +947,18 @@ public:
       // X = 20 (centerline->left imager) + color->depth baseline.
       return {viam::sdk::GeometryConfig(viam::sdk::pose{35, 0, -8.9},
                                         viam::sdk::box({99, 23, 20}), "box")};
+    }
+    if (model && (*model == "D405")) {
+      // D405: 42 (w) x 42 (h) x 23 (d) mm, datasheet 337029-017 Table 3-54.
+      // The D405 has no dedicated RGB sensor: the color stream comes from
+      // the left stereo imager, so the color->depth translation is ~0 and
+      // the origin is the left imager itself.
+      // X = 9 (mount centerline->left imager, Table 4-20); the imagers sit
+      // on the housing's horizontal centerline, so y = 0.
+      // Z = 23/2 - 3.7 (depth start point behind front glass, Table 4-16)
+      //   = 7.8 mm.
+      return {viam::sdk::GeometryConfig(viam::sdk::pose{9, 0, -7.8},
+                                        viam::sdk::box({42, 42, 23}), "box")};
     }
     // Default: D435 / D435i geometry.
     // D435: 90 (w) x 25 (h) x 25 (d) mm. Z = 25/2 - 4.2 = 8.3 mm.

--- a/test/device_tests.cpp
+++ b/test/device_tests.cpp
@@ -104,6 +104,9 @@ public:
 // SimpleStreamProfile: Wrapper that can convert to SimpleVideoStreamProfile
 class SimpleStreamProfile {
 public:
+  // All fake profiles are video profiles.
+  template <typename T> bool is() const { return true; }
+
   template <typename T> T as() const {
     return T{format_, width_, height_, fps_, stream_index_};
   }
@@ -293,6 +296,21 @@ TEST_F(DeviceTest, GetCameraModel_D415Device_ReturnsD415) {
   // Verify
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "D415");
+}
+
+TEST_F(DeviceTest, GetCameraModel_D405Device_ReturnsD405) {
+  // Setup expectations
+  EXPECT_CALL(*mock_device_, supports(RS2_CAMERA_INFO_NAME))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*mock_device_, get_info(RS2_CAMERA_INFO_NAME))
+      .WillOnce(Return("Intel RealSense D405"));
+
+  // Execute
+  auto result = getCameraModel(mock_device_);
+
+  // Verify
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "D405");
 }
 
 TEST_F(DeviceTest, GetCameraModel_UnsupportedDevice_ReturnsNullopt) {
@@ -1060,23 +1078,24 @@ TEST_F(DeviceTest, DisableAutoExposurePriority_ColorSensor_DisablesOption) {
       << "Should not log errors for successful operation";
 }
 
-TEST_F(DeviceTest, DisableAutoExposurePriority_DepthSensor_DoesNothing) {
+TEST_F(DeviceTest, DisableAutoExposurePriority_OptionUnsupported_DoesNothing) {
   test_utils::LogCaptureFixture log_capture;
   viam::sdk::LogSource logger;
 
   MockSensor mock_sensor;
-  mock_sensor.set_sensor_type(false, true); // Depth sensor
+  mock_sensor.set_sensor_type(false, true); // Stereo sensor (e.g. D405)
 
-  // Setup expectations - should not call set_option for depth sensor
-  EXPECT_CALL(mock_sensor, supports(_)).Times(0);
+  // Sensor does not expose the auto-exposure priority option
+  EXPECT_CALL(mock_sensor, supports(RS2_OPTION_AUTO_EXPOSURE_PRIORITY))
+      .WillOnce(Return(false));
   EXPECT_CALL(mock_sensor, set_option(_, _)).Times(0);
 
   // Execute
   disableAutoExposurePriority(mock_sensor, logger);
 
-  // Verify no logs (function returns early for non-color sensors)
+  // Verify no logs (function returns early if option not supported)
   auto all_logs = log_capture.get_records();
-  EXPECT_EQ(all_logs.size(), 0) << "Should not log for non-color sensors";
+  EXPECT_EQ(all_logs.size(), 0) << "Should not log when option not supported";
 }
 
 TEST_F(DeviceTest, DisableAutoExposurePriority_SetOptionFails_LogsWarning) {
@@ -1103,33 +1122,6 @@ TEST_F(DeviceTest, DisableAutoExposurePriority_SetOptionFails_LogsWarning) {
               ::testing::HasSubstr("Failed to disable Auto-Exposure Priority"));
   EXPECT_THAT(warning_logs[0].message,
               ::testing::HasSubstr("Option not supported"));
-}
-
-TEST_F(DeviceTest, DisableAutoExposurePriority_UnknownSensorType_LogsError) {
-  test_utils::LogCaptureFixture log_capture;
-  viam::sdk::LogSource logger;
-
-  MockSensor mock_sensor;
-  mock_sensor.set_sensor_type(
-      false, false); // Unknown sensor (neither color nor depth)
-
-  // Execute - should log error for unknown sensor type
-  disableAutoExposurePriority(mock_sensor, logger);
-
-  // Verify error log for unknown sensor
-  auto error_logs = log_capture.get_error_logs();
-  ASSERT_GE(error_logs.size(), 1) << "Should log error for unknown sensor type";
-
-  // Check that at least one error mentions the failure
-  bool found_error = false;
-  for (const auto &log : error_logs) {
-    if (log.message.find("Failed to get sensor type") != std::string::npos ||
-        log.message.find("Invalid sensor type") != std::string::npos) {
-      found_error = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found_error) << "Should log error for unknown sensor type";
 }
 
 TEST_F(DeviceTest,
@@ -1322,6 +1314,175 @@ TEST_F(DeviceTest,
       << "Should log that auto-exposure was disabled for color";
   EXPECT_TRUE(found_matching_profiles_log)
       << "Should log that matching profiles were found";
+}
+
+// D405 topology: a single stereo sensor serves both the color and the depth
+// streams and does not cast to rs2::color_sensor.
+TEST_F(DeviceTest, CreateSwD2CAlignConfig_D405SingleSensor_ServesBothStreams) {
+  test_utils::LogCaptureFixture log_capture;
+  viam::sdk::LogSource logger;
+
+  auto mock_device = std::make_shared<SimpleDevice>();
+
+  SimpleSensor stereo_sensor;
+  stereo_sensor.set_sensor_type(false, true); // Depth sensor only
+
+  SimpleStreamProfile color_profile;
+  color_profile.format_ = RS2_FORMAT_RGB8;
+  color_profile.width_ = 640;
+  color_profile.height_ = 480;
+  color_profile.fps_ = 30;
+  color_profile.stream_index_ = 0;
+
+  SimpleStreamProfile depth_profile;
+  depth_profile.format_ = RS2_FORMAT_Z16;
+  depth_profile.width_ = 640;
+  depth_profile.height_ = 480;
+  depth_profile.fps_ = 30;
+  depth_profile.stream_index_ = 0;
+
+  stereo_sensor.set_stream_profiles({color_profile, depth_profile});
+
+  // Global timestamp is enabled once for the single sensor; the sensor
+  // serves color, so auto-exposure priority is disabled on it too.
+  EXPECT_CALL(*stereo_sensor.mock(), supports(RS2_OPTION_GLOBAL_TIME_ENABLED))
+      .Times(1)
+      .WillOnce(Return(true));
+  EXPECT_CALL(*stereo_sensor.mock(),
+              set_option(RS2_OPTION_GLOBAL_TIME_ENABLED, 1.0f))
+      .Times(1);
+  EXPECT_CALL(*stereo_sensor.mock(),
+              supports(RS2_OPTION_AUTO_EXPOSURE_PRIORITY))
+      .Times(1)
+      .WillOnce(Return(true));
+  EXPECT_CALL(*stereo_sensor.mock(),
+              set_option(RS2_OPTION_AUTO_EXPOSURE_PRIORITY, 0.0f))
+      .Times(1);
+
+  mock_device->set_sensors({stereo_sensor});
+
+  RsResourceConfig viam_config("d405_serial", "test_camera",
+                               {realsense::sensors::SensorType::color,
+                                realsense::sensors::SensorType::depth},
+                               std::optional<int>{640},
+                               std::optional<int>{480});
+
+  auto result =
+      createSwD2CAlignConfig<SimpleDevice, SimpleConfig, rs2::color_sensor,
+                             rs2::depth_sensor, SimpleVideoStreamProfile,
+                             RsResourceConfig>(mock_device, viam_config,
+                                               logger);
+
+  EXPECT_NE(result, nullptr)
+      << "createSwD2CAlignConfig should build a config from a single sensor "
+         "serving both streams";
+
+  auto all_logs = log_capture.get_records();
+  bool found_matching_profiles_log = false;
+  for (const auto &log : all_logs) {
+    if (log.message.find("Found matching color and depth stream profiles") !=
+        std::string::npos) {
+      found_matching_profiles_log = true;
+    }
+  }
+  EXPECT_TRUE(found_matching_profiles_log)
+      << "Should log that matching profiles were found";
+}
+
+TEST_F(DeviceTest, CreateSingleSensorConfig_D405ColorFromStereoSensor) {
+  test_utils::LogCaptureFixture log_capture;
+  viam::sdk::LogSource logger;
+
+  auto mock_device = std::make_shared<SimpleDevice>();
+
+  SimpleSensor stereo_sensor;
+  stereo_sensor.set_sensor_type(false, true); // Depth sensor only
+
+  SimpleStreamProfile color_profile;
+  color_profile.format_ = RS2_FORMAT_RGB8;
+  color_profile.width_ = 640;
+  color_profile.height_ = 480;
+  color_profile.fps_ = 30;
+  color_profile.stream_index_ = 0;
+
+  SimpleStreamProfile depth_profile;
+  depth_profile.format_ = RS2_FORMAT_Z16;
+  depth_profile.width_ = 640;
+  depth_profile.height_ = 480;
+  depth_profile.fps_ = 30;
+  depth_profile.stream_index_ = 0;
+
+  stereo_sensor.set_stream_profiles({depth_profile, color_profile});
+
+  EXPECT_CALL(*stereo_sensor.mock(), supports(RS2_OPTION_GLOBAL_TIME_ENABLED))
+      .Times(1)
+      .WillOnce(Return(true));
+  EXPECT_CALL(*stereo_sensor.mock(),
+              set_option(RS2_OPTION_GLOBAL_TIME_ENABLED, 1.0f))
+      .Times(1);
+
+  mock_device->set_sensors({stereo_sensor});
+
+  RsResourceConfig viam_config(
+      "d405_serial", "test_camera", {realsense::sensors::SensorType::color},
+      std::optional<int>{640}, std::optional<int>{480});
+
+  // Request a color-only config even though no sensor casts to
+  // rs2::color_sensor.
+  auto result =
+      createSingleSensorConfig<SimpleDevice, SimpleConfig, rs2::color_sensor,
+                               SimpleVideoStreamProfile, RsResourceConfig>(
+          mock_device, viam_config, logger);
+
+  EXPECT_NE(result, nullptr) << "createSingleSensorConfig should find the "
+                                "color stream on the stereo sensor";
+}
+
+TEST_F(DeviceTest, CreateSwD2CAlignConfig_NoColorProfiles_ReturnsNullptr) {
+  test_utils::LogCaptureFixture log_capture;
+  viam::sdk::LogSource logger;
+
+  auto mock_device = std::make_shared<SimpleDevice>();
+
+  SimpleSensor depth_only_sensor;
+  depth_only_sensor.set_sensor_type(false, true);
+
+  SimpleStreamProfile depth_profile;
+  depth_profile.format_ = RS2_FORMAT_Z16;
+  depth_profile.width_ = 640;
+  depth_profile.height_ = 480;
+  depth_profile.fps_ = 30;
+  depth_profile.stream_index_ = 0;
+  depth_only_sensor.set_stream_profiles({depth_profile});
+
+  EXPECT_CALL(*depth_only_sensor.mock(),
+              supports(RS2_OPTION_GLOBAL_TIME_ENABLED))
+      .Times(1)
+      .WillOnce(Return(true));
+  EXPECT_CALL(*depth_only_sensor.mock(),
+              set_option(RS2_OPTION_GLOBAL_TIME_ENABLED, 1.0f))
+      .Times(1);
+  // No color profiles served, so auto-exposure priority is never touched.
+  EXPECT_CALL(*depth_only_sensor.mock(),
+              supports(RS2_OPTION_AUTO_EXPOSURE_PRIORITY))
+      .Times(0);
+
+  mock_device->set_sensors({depth_only_sensor});
+
+  RsResourceConfig viam_config("test_serial", "test_camera",
+                               {realsense::sensors::SensorType::color,
+                                realsense::sensors::SensorType::depth},
+                               std::optional<int>{640},
+                               std::optional<int>{480});
+
+  auto result =
+      createSwD2CAlignConfig<SimpleDevice, SimpleConfig, rs2::color_sensor,
+                             rs2::depth_sensor, SimpleVideoStreamProfile,
+                             RsResourceConfig>(mock_device, viam_config,
+                                               logger);
+
+  EXPECT_EQ(result, nullptr)
+      << "Should return nullptr, not crash, when no color stream exists";
 }
 
 } // namespace test

--- a/test/encoding_tests.cpp
+++ b/test/encoding_tests.cpp
@@ -212,6 +212,62 @@ TEST_F(EncodingTest, EncodeDepthRAW_VariousDepthRanges) {
   EXPECT_EQ(max_result.bytes, expected_max_depth_values);
 }
 
+TEST_F(EncodingTest, EncodeDepthRAW_D405DepthUnitsRescaledToMillimeters) {
+  // The D405 defaults to 0.1 mm depth units (100 µm), so raw values must be
+  // rescaled to the millimeters that image/vnd.viam.dep encodes.
+  std::vector<uint8_t> depth_bytes{
+      0x64, 0x00, // 100 raw units   -> 10 mm
+      0x39, 0x30, // 12345 raw units -> 1234.5 -> 1235 mm (rounded)
+      0xFF, 0xFF  // 65535 raw units -> 6553.5 -> 6554 mm
+  };
+  std::vector<uint8_t> expected_values{
+      0x44, 0x45, 0x50, 0x54, 0x48, 0x4d, 0x41, 0x50, // "DEPTHMAP"
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, // Width: 3
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // Height: 1
+      0x00, 0x0A,                                     // Depth pixel 1: 10
+      0x04, 0xD3,                                     // Depth pixel 2: 1235
+      0x19, 0x9A                                      // Depth pixel 3: 6554
+  };
+
+  auto result = encodeDepthRAWToResponse(depth_bytes.data(), 3, 1, 0.1f);
+  EXPECT_EQ(result.source_name, "depth");
+  EXPECT_EQ(result.mime_type, "image/vnd.viam.dep");
+  EXPECT_EQ(result.bytes, expected_values);
+}
+
+TEST_F(EncodingTest, EncodeDepthRAW_ScaleSaturatesAtUint16Max) {
+  // Values that overflow uint16 after rescaling saturate at 65535 rather
+  // than wrapping.
+  std::vector<uint8_t> depth_bytes{0x40, 0x9C}; // 40000 = 0x9C40
+  std::vector<uint8_t> expected_values{
+      0x44, 0x45, 0x50, 0x54, 0x48, 0x4d, 0x41, 0x50, // "DEPTHMAP"
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // Width: 1
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // Height: 1
+      0xFF, 0xFF                                      // 80000 mm -> 65535
+  };
+
+  auto result = encodeDepthRAWToResponse(depth_bytes.data(), 1, 1, 2.0f);
+  EXPECT_EQ(result.bytes, expected_values);
+}
+
+TEST_F(EncodingTest, EncodeDepthRAW_UnitScaleMatchesDefault) {
+  // An explicit 1 mm/unit scale must produce the same bytes as the default.
+  auto scaled = encodeDepthRAWToResponse(test_depth_data_.data(), test_width_,
+                                         test_height_, 1.0f);
+  auto unscaled = encodeDepthRAWToResponse(test_depth_data_.data(), test_width_,
+                                           test_height_);
+  EXPECT_EQ(scaled.bytes, unscaled.bytes);
+}
+
+TEST_F(EncodingTest, EncodeDepthRAW_InvalidScaleThrows) {
+  EXPECT_THROW(
+      {
+        encodeDepthRAWToResponse(test_depth_data_.data(), test_width_,
+                                 test_height_, 0.0f);
+      },
+      std::runtime_error);
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
The D405 differs from other supported D400 cameras in two ways that the module previously could not handle:

- It has no dedicated RGB sensor: the single stereo sensor serves both the color and depth streams and does not cast to rs2::color_sensor. Sensor discovery in createSingleSensorConfig/createSwD2CAlignConfig now selects streams by profile format across all sensors instead of looking for dedicated color and depth sensors, and auto-exposure priority is disabled on whichever sensor serves color. Non-video profiles (e.g. IMU motion streams) are skipped explicitly.

- Its default depth units are 0.1 mm rather than 1 mm. GetImage depth encoding now rescales raw depth values to the millimeters that image/vnd.viam.dep encodes, using the frame's reported depth units (pass-through for 1 mm devices). GetPointCloud was already correct (rs2::pointcloud applies the scale internally).

Also adds the D405 entry to get_geometries (42x42x23 mm, left-imager origin, from datasheet 337029-017 Tables 3-54/4-16/4-20; color->depth baseline is ~0 because color comes from the left imager) and documents D405 frame semantics in the README.

Firmware auto-detect needs no change: since the 5.13 unification the D400-series firmware line covers the D405, and librealsense 2.57.7 recommends 5.17.0.10 for all D400 PIDs.

Validated on a physical D405.