### PR TITLE
Make codecov report-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,5 +89,6 @@ jobs:
           # Token is optional for public repos, but recommended for reliability
           # If uploads fail, ensure CODECOV_TOKEN is set in repository secrets
           token: ${{ secrets.CODECOV_TOKEN || '' }}
-          fail_ci_if_error: true
+          # Coverage is report-only: an upload failure should not fail CI
+          fail_ci_if_error: false
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,17 @@
 # It is used to configure the code coverage reporting for the module.
 # For more information about the configuration options, see:
 # https://docs.codecov.io/docs/codecov-yaml or https://docs.codecov.com/docs/github-tutorial
+# Statuses are informational: they still report coverage on PRs but always
+# resolve as success, so coverage can never fail CI or block a merge.
 coverage:
   status:
     project:
       default:
         target: 70%
+        informational: true
+    patch:
+      default:
+        informational: true
 ignore:
   - "test/**/*"
   - "build-*/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,17 +2,11 @@
 # It is used to configure the code coverage reporting for the module.
 # For more information about the configuration options, see:
 # https://docs.codecov.io/docs/codecov-yaml or https://docs.codecov.com/docs/github-tutorial
-# Statuses are informational: they still report coverage on PRs but always
-# resolve as success, so coverage can never fail CI or block a merge.
 coverage:
   status:
     project:
       default:
         target: 70%
-        informational: true
-    patch:
-      default:
-        informational: true
 ignore:
   - "test/**/*"
   - "build-*/**/*"

--- a/src/module/encoding.cpp
+++ b/src/module/encoding.cpp
@@ -231,13 +231,5 @@ encodeRGBPointsToPCD(std::pair<rs2::points, rs2::video_frame> &&data,
   return pcdBytes;
 }
 
-// TEMP: never-called probe to verify codecov/patch is informational.
-// Revert before merge.
-int codecovPatchProbe(int x) {
-  int doubled = x * 2;
-  int shifted = doubled + 1;
-  return shifted;
-}
-
 } // namespace encoding
 } // namespace realsense

--- a/src/module/encoding.cpp
+++ b/src/module/encoding.cpp
@@ -231,5 +231,13 @@ encodeRGBPointsToPCD(std::pair<rs2::points, rs2::video_frame> &&data,
   return pcdBytes;
 }
 
+// TEMP: never-called probe to verify codecov/patch is informational.
+// Revert before merge.
+int codecovPatchProbe(int x) {
+  int doubled = x * 2;
+  int shifted = doubled + 1;
+  return shifted;
+}
+
 } // namespace encoding
 } // namespace realsense


### PR DESCRIPTION
## Description

Pretty annoying that codecov causes ci failures ❌ 

Mark the project and patch coverage statuses as informational so they still post real numbers on PRs but always resolve green, and stop Codecov upload errors from failing the test job.


## Test

See how report does not cause CI failure below