### PR TITLE
fix(properties): report identity extrinsics for the color-registered cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following attributes are available for `viam:camera:realsense` cameras:
 
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
-| `sensors` | list | Optional | The RealSense data streams you want your robot to sense from. A list containing the strings `color` and/or `depth`. List order does not affect `get_properties`: it returns color intrinsics whenever `color` is configured (depth intrinsics otherwise) and always anchors `extrinsic_parameters` to the depth left imager — see [Frame origin and `extrinsic_parameters`](#frame-origin-and-extrinsic_parameters). Use [`GetImages`](https://docs.viam.com/components/camera/#getimages) to retrieve images from all listed sensors simultaneously. Defaults to `["color", "depth"]` if omitted. |
+| `sensors` | list | Optional | The RealSense data streams you want your robot to sense from. A list containing the strings `color` and/or `depth`. List order does not affect `get_properties`: it returns color intrinsics whenever `color` is configured (depth intrinsics otherwise), and `extrinsic_parameters` is always identity — see [Frame origin and `extrinsic_parameters`](#frame-origin-and-extrinsic_parameters). Use [`GetImages`](https://docs.viam.com/components/camera/#getimages) to retrieve images from all listed sensors simultaneously. Defaults to `["color", "depth"]` if omitted. |
 | `width_px` | int | Optional | The width of the output images in pixels. If the RealSense cannot produce the requested resolution, the component will fail to be built. |
 | `height_px` | int | Optional | The height of the output images in pixels. If the RealSense cannot produce the requested resolution, the component will fail to be built. |
 | `serial_number` | string | Optional | The serial number of the specific RealSense camera to use. To find your camera's serial number, the serial number of each plugged-in and available RealSense camera will be logged on module startup. You can also find device information using the [RealSense SDK directly](https://github.com/IntelRealSense/librealsense/blob/master/tools/enumerate-devices/readme.md). If this field is omitted or is an empty string, the module will use the first RealSense camera it detects. |
@@ -91,35 +91,25 @@ The following methods of the Viam camera API are supported:
 
 #### Frame origin and `extrinsic_parameters`
 
-The RealSense D4xx series has multiple imagers at slightly different positions on the device. The **camera frame origin is anchored at the depth left imager** for `extrinsic_parameters`.
+The RealSense D4xx series has multiple imagers at slightly different positions on the device. The **camera frame origin is the color (RGB) sensor** whenever `color` is configured, and the depth left imager otherwise.
 
-> **Note:** the bounding-box geometries returned by `get_geometries` are anchored at the **color (RGB) sensor**, not the depth left imager, since `get_properties` reports color intrinsics and the poses callers derive from the images are in the color frame. This differs from the `extrinsic_parameters` reference frame described below, and from the `GetPointCloud` output (which is in the depth frame). If you compose geometries and point clouds in the same frame, account for the ~14.7 mm (D435/D435i) color→depth baseline.
+Everything this module reports lives in that single frame:
 
-`get_properties` returns color intrinsics whenever `color` is configured (depth intrinsics otherwise), regardless of `sensors` list order. `extrinsic_parameters` is always the transform from the intrinsics sensor's frame to the depth left imager (the camera reference frame). With the default `["color", "depth"]` config this is the color→depth transform; when only depth is configured — or only one sensor is configured — extrinsics are identity (zero translation).
+- `get_properties` returns that sensor's intrinsics — color when configured, depth otherwise — regardless of `sensors` list order.
+- `GetPointCloud` emits its vertices in the same frame: depth is registered to the color frame with `rs2::align` before it is deprojected.
+- `get_geometries` anchors its bounding box at the color sensor.
+
+Because the point cloud and the reported intrinsics already share a frame, **`extrinsic_parameters` is identity**.
 
 | Field | Contents |
 | ----- | -------- |
 | `intrinsic_parameters` | `fx`, `fy`, `ppx`, `ppy` for the color sensor when configured, otherwise depth. |
-| `extrinsic_parameters.translation` | Transform from the intrinsics sensor's frame to the depth left imager (camera reference frame), in millimeters. Approximately `{-14.7, 0, 0}` mm for D435/D435i when color is configured (color→depth direction); identity when only depth is configured. |
+| `extrinsic_parameters.translation` | Zero. The point cloud is already registered to the frame the intrinsics describe. |
 | `extrinsic_parameters.orientation` | Identity — the sub-degree rotation between depth and color is treated as zero. |
 
-With the default config (`["color", "depth"]`), if you derive a pose from color-stream intrinsics (e.g. an AprilTag detector or any PnP solver), the resulting pose is in the **color sensor frame**. To express it in the camera reference frame — which is what Viam composes against other components and the world frame — add `extrinsic_parameters.translation`:
+Project a point cloud vertex straight through `intrinsic_parameters`; do not apply an extrinsic offset first. Likewise, a pose you derive from the color stream (e.g. an AprilTag detector or any PnP solver) is already in the camera frame that Viam composes against the world frame and other components — no correction needed.
 
-```python
-props = await camera.get_properties()
-ox = props.extrinsic_parameters.translation.x  # mm
-oy = props.extrinsic_parameters.translation.y  # mm
-oz = props.extrinsic_parameters.translation.z  # mm
-
-# pose_t is the detector's translation output in meters, in the color frame.
-pose_in_camera_frame_mm = (
-    pose_t[0] * 1000 + ox,
-    pose_t[1] * 1000 + oy,
-    pose_t[2] * 1000 + oz,
-)
-```
-
-Skipping this step produces an offset in X equal to the color-to-depth baseline (roughly 15 mm on D435/D435i), visible as soon as the camera frame is composed against the world frame or other components.
+> **Upgrading from 0.22.4:** that release registered the point cloud to the color frame but still reported the ~15 mm color→depth baseline in `extrinsic_parameters.translation`. Consumers that subtract the translation before projecting — including the RDK's `camera.Properties.PointToPixel` — re-applied a baseline `rs2::align` had already removed, shifting every projected point horizontally by `fx · T / Z` (about 22 px at 0.63 m on a D435). If you added `extrinsic_parameters.translation` to color-derived poses to work around this, remove that step.
 
 #### `GetImages` source names
 

--- a/src/module/extrinsics.hpp
+++ b/src/module/extrinsics.hpp
@@ -13,9 +13,13 @@ namespace extrinsics {
 /// @return Extrinsic parameters representing the transformation from
 /// from_stream to to_stream. If streams are identical, returns identity
 /// extrinsics.
+///
+/// Templated on the profile types so tests can substitute a stand-in exposing
+/// unique_id() and get_extrinsics_to(); a real rs2::stream_profile can only be
+/// handed out by a live device.
+template <typename FromStreamT, typename ToStreamT>
 inline viam::sdk::Camera::extrinsic_parameters
-get_extrinsics(const rs2::stream_profile &from_stream,
-               const rs2::stream_profile &to_stream) {
+get_extrinsics(const FromStreamT &from_stream, const ToStreamT &to_stream) {
   viam::sdk::Camera::extrinsic_parameters extrinsics;
 
   // If streams are the same, return identity extrinsics
@@ -45,6 +49,30 @@ get_extrinsics(const rs2::stream_profile &from_stream,
   extrinsics.orientation.theta = 0.0;
 
   return extrinsics;
+}
+
+/// @brief The extrinsic parameters get_properties() publishes.
+/// @param reference_stream The stream whose intrinsics get_properties() reports
+/// @return Identity extrinsics.
+///
+/// extrinsic_parameters describes the transform from the frame the point cloud
+/// is emitted in to the frame the reported intrinsics describe. Those are the
+/// same frame: get_point_cloud() aligns depth to color before deprojecting (see
+/// device::PointCloudFilter), so the cloud lands in the color frame, which is
+/// also the stream get_properties() takes its intrinsics from whenever color is
+/// configured. When only one sensor is configured there is no second frame to
+/// be in — and no point cloud at all, since deprojection needs both streams.
+/// Either way the transform is @p reference_stream to itself: identity.
+///
+/// Do NOT publish the real depth<->color baseline here. Consumers subtract
+/// extrinsic_parameters.translation before projecting a cloud point through the
+/// reported intrinsics (rdk's camera.Properties.PointToPixel), so a non-zero
+/// translation re-applies a baseline rs2::align has already removed, shifting
+/// every projected point by fx * T / Z — about 22 px at 0.63 m on a D435.
+template <typename StreamProfileT>
+inline viam::sdk::Camera::extrinsic_parameters
+get_reported_extrinsics(const StreamProfileT &reference_stream) {
+  return get_extrinsics(reference_stream, reference_stream);
 }
 
 } // namespace extrinsics

--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -787,8 +787,7 @@ public:
       }
       auto fillResp = [this](viam::sdk::Camera::properties &p,
                              rs2_intrinsics const &props,
-                             const rs2::stream_profile &stream,
-                             const rs2::stream_profile &ref_stream) {
+                             const rs2::stream_profile &reference_stream) {
         p.supports_pcd = true;
         p.intrinsic_parameters.width_px = props.width;
         p.intrinsic_parameters.height_px = props.height;
@@ -797,9 +796,10 @@ public:
         p.intrinsic_parameters.center_x_px = props.ppx;
         p.intrinsic_parameters.center_y_px = props.ppy;
 
-        // Calculate extrinsics from stream to reference stream
+        // Identity: the point cloud is emitted in the same frame these
+        // intrinsics describe. See extrinsics::get_reported_extrinsics.
         p.extrinsic_parameters =
-            realsense::extrinsics::get_extrinsics(stream, ref_stream);
+            realsense::extrinsics::get_reported_extrinsics(reference_stream);
 
         switch (props.model) {
         case RS2_DISTORTION_BROWN_CONRADY:
@@ -878,21 +878,23 @@ public:
               << e.what();
         }
 
-        // The camera reference frame is always the depth left imager, matching
-        // get_geometries. Intrinsics come from color when configured (the
-        // stream most callers derive poses from), otherwise depth. Extrinsics
-        // are therefore intrinsics_stream -> depth, which is identity whenever
-        // depth is the intrinsics stream or only one sensor is configured.
-        const rs2::video_stream_profile &intrinsics_stream =
+        // The camera reference frame is the color imager when color is
+        // configured (the stream most callers derive poses from), otherwise
+        // depth. Everything this resource reports is expressed in that one
+        // frame: the intrinsics below, the point cloud get_point_cloud() emits
+        // (it aligns depth to color before deprojecting — see
+        // device::PointCloudFilter), and the box pose from get_geometries().
+        // Extrinsics are therefore identity; see
+        // extrinsics::get_reported_extrinsics for why publishing the real
+        // depth<->color baseline here double-corrects consumers.
+        const rs2::video_stream_profile &reference_stream =
             color_stream ? color_stream : depth_stream;
-        if (not intrinsics_stream) {
+        if (not reference_stream) {
           throw std::runtime_error(
               "neither color nor depth stream is available");
         }
-        const rs2::video_stream_profile &ref_stream =
-            depth_stream ? depth_stream : color_stream;
-        auto props = intrinsics_stream.get_intrinsics();
-        fillResp(response, props, intrinsics_stream, ref_stream);
+        auto props = reference_stream.get_intrinsics();
+        fillResp(response, props, reference_stream);
       } // End scope for my_dev lock
 
       VIAM_RESOURCE_LOG(debug) << "[get_properties] end";
@@ -915,7 +917,11 @@ public:
     // intrinsics and the images/derived poses callers work with are in the
     // color frame. Box dimensions and the depth-imager placement come from the
     // Intel RealSense D400-Series Datasheet (337029-005); the color sensor's
-    // position is then derived from the color->depth extrinsics.
+    // position is then derived from the color->depth extrinsics. Those are the
+    // physical baseline librealsense reports for the model, used here only to
+    // place the box at build time — not the identity extrinsics get_properties
+    // publishes (see extrinsics::get_reported_extrinsics). The poses below are
+    // constants; nothing here reads extrinsics at runtime.
     //   - Module dimensions: Table 3-43 (D415), Table 3-44 (D435/D435i).
     //   - The depth left imager is offset from the module centerline (the box
     //     center) per Table 4-15 (17.5 mm for D435/D435i, 20 mm for D415), on

--- a/test/extrinsics_test.cpp
+++ b/test/extrinsics_test.cpp
@@ -4,10 +4,102 @@
 
 using namespace realsense;
 
-// Note: get_extrinsics with actual rs2::stream_profile objects requires
-// a real RealSense device. The extrinsics function returns identity orientation
-// and translation based on RealSense SDK data.
-// Full integration tests with real hardware are performed separately.
+// A real rs2::stream_profile can only be handed out by a live device, so these
+// tests drive extrinsics.hpp through the same duck-typed surface it uses:
+// unique_id() and get_extrinsics_to(). This mirrors how device.hpp is tested.
+class FakeStreamProfile {
+public:
+  FakeStreamProfile(int unique_id, rs2_extrinsics extrinsics_to_other)
+      : unique_id_(unique_id), extrinsics_to_other_(extrinsics_to_other) {}
 
-// Placeholder test to ensure the test file compiles
-TEST(ExtrinsicsTest, Placeholder) { EXPECT_TRUE(true); }
+  int unique_id() const { return unique_id_; }
+
+  rs2_extrinsics get_extrinsics_to(const FakeStreamProfile &) const {
+    return extrinsics_to_other_;
+  }
+
+private:
+  int unique_id_;
+  rs2_extrinsics extrinsics_to_other_;
+};
+
+namespace {
+
+// Measured color->depth extrinsics from a D435 (translation in meters, as
+// librealsense reports it). Rotation is ignored by get_extrinsics.
+constexpr rs2_extrinsics kD435ColorToDepth = {
+    {1, 0, 0, 0, 1, 0, 0, 0, 1},          // rotation
+    {-0.015044f, -0.000173f, -0.000428f}, // translation
+};
+
+void expectIdentityOrientation(
+    const viam::sdk::Camera::extrinsic_parameters &extrinsics) {
+  EXPECT_DOUBLE_EQ(extrinsics.orientation.x, 0.0);
+  EXPECT_DOUBLE_EQ(extrinsics.orientation.y, 0.0);
+  EXPECT_DOUBLE_EQ(extrinsics.orientation.z, 1.0);
+  EXPECT_DOUBLE_EQ(extrinsics.orientation.theta, 0.0);
+}
+
+void expectZeroTranslation(
+    const viam::sdk::Camera::extrinsic_parameters &extrinsics) {
+  EXPECT_DOUBLE_EQ(extrinsics.translation.x(), 0.0);
+  EXPECT_DOUBLE_EQ(extrinsics.translation.y(), 0.0);
+  EXPECT_DOUBLE_EQ(extrinsics.translation.z(), 0.0);
+}
+
+} // namespace
+
+// Guards the regression tests below against being vacuously true: a non-zero
+// baseline between two *different* streams must still come through, in mm.
+TEST(ExtrinsicsTest, ConvertsMetersToMillimetersBetweenDistinctStreams) {
+  const FakeStreamProfile color{0, kD435ColorToDepth};
+  const FakeStreamProfile depth{1, kD435ColorToDepth};
+
+  const auto result = extrinsics::get_extrinsics(color, depth);
+
+  EXPECT_NEAR(result.translation.x(), -15.044, 1e-3);
+  EXPECT_NEAR(result.translation.y(), -0.173, 1e-3);
+  EXPECT_NEAR(result.translation.z(), -0.428, 1e-3);
+  expectIdentityOrientation(result);
+}
+
+TEST(ExtrinsicsTest, IsIdentityForTheSameStream) {
+  const FakeStreamProfile color{0, kD435ColorToDepth};
+
+  const auto result = extrinsics::get_extrinsics(color, color);
+
+  expectZeroTranslation(result);
+  expectIdentityOrientation(result);
+}
+
+// Regression test for the extrinsic double-correction shipped in 0.22.4.
+//
+// get_point_cloud() aligns depth to the color frame before deprojecting, so the
+// cloud is already registered to the stream whose intrinsics get_properties()
+// reports. Publishing the depth<->color baseline made consumers that subtract
+// extrinsic_parameters.translation before projecting (rdk's
+// camera.Properties.PointToPixel) re-apply a baseline rs2::align had already
+// removed — a ~22 px X shift at 0.63 m on a D435.
+//
+// The reference stream is color when color is configured, depth otherwise; in
+// every case the reported extrinsics must be identity.
+TEST(ExtrinsicsTest, ReportedExtrinsicsAreIdentityForColorAndDepthConfigured) {
+  // Reference stream is color; it has a real, non-zero baseline to depth.
+  const FakeStreamProfile color{0, kD435ColorToDepth};
+
+  const auto result = extrinsics::get_reported_extrinsics(color);
+
+  expectZeroTranslation(result);
+  expectIdentityOrientation(result);
+}
+
+TEST(ExtrinsicsTest, ReportedExtrinsicsAreIdentityForASingleConfiguredSensor) {
+  // sensors: ["depth"] — depth is both the reference stream and the only frame
+  // there is. Same for sensors: ["color"].
+  const FakeStreamProfile depth{1, kD435ColorToDepth};
+
+  const auto result = extrinsics::get_reported_extrinsics(depth);
+
+  expectZeroTranslation(result);
+  expectIdentityOrientation(result);
+}


### PR DESCRIPTION
## What

`get_properties()` now reports **identity** extrinsics instead of the depth→color baseline.

## Why

#161 (shipped in 0.22.4) made `get_point_cloud()` align depth to the color frame. But `get_properties()` kept advertising the depth→color offset, so the driver was telling consumers the cloud was in a frame it no longer sits in.

Anything that applies that offset before projecting — including RDK's `camera.Properties.PointToPixel` — re-corrects for a baseline `rs2::align` already removed. Result: every projected point lands **~22 px off horizontally**, in the wrong direction.

The point cloud is already in the color frame. The intrinsics we report are the color intrinsics. Same frame ⇒ the transform between them is identity.

## Verified on hardware

Live D435 (part `96657d75`), before and after reload:

| | 0.22.4 | This PR |
|---|---|---|
| `translation.x` | −15.044 | **0** |
| `translation.y` | −0.173 | **0** |
| `translation.z` | −0.428 | **0** |
| `focalXPx` | 922.700 | 922.700 (unchanged) |

Intrinsics are byte-identical, confirming only the extrinsics path changed.

`147/147` tests pass (144 on main — the placeholder test file became 4 real tests). Lint clean.

## Does this undo #161?

No. The alignment stays exactly as it was. #161 fixed consumers that project *without* extrinsics (`detections-to-segments`); this fixes the ones that *do*. Identity + a color-registered cloud is the only state that satisfies both.

---

<details>
<summary><b>Why identity is correct for every <code>sensors</code> config (not just the default)</b></summary>

<br>

I checked each combination rather than hardcoding identity:

| `sensors` | cloud emitted in | before | after |
|---|---|---|---|
| `["color","depth"]` | color (`rs2::align`) | color→depth (−15 mm) ❌ | identity |
| `["color"]` | no cloud — `get_point_cloud` throws on the missing depth frame | identity ✅ | identity |
| `["depth"]` | no cloud — `PointCloudFilter` throws on the missing color frame | identity ✅ | identity |

With one sensor there is no second frame to be in, and no point cloud at all. Those cases already returned identity via the existing same-stream path in `get_extrinsics`, so **only the both-sensors case changes behavior**.

</details>

<details>
<summary><b>How three PRs drifted apart</b></summary>

<br>

- **#141** anchored extrinsics to the depth left imager
- **#148** anchored `get_geometries` to the color sensor
- **#161** registered the point cloud to the color frame

Only #141's extrinsics were left behind. The two comments even contradicted each other in the source — `get_properties` claimed "the camera reference frame is always the depth left imager, matching get_geometries", while `get_geometries` claimed the origin is the color sensor.

After this PR the intrinsics, the point cloud, and the geometry box pose all agree on one frame.

</details>

<details>
<summary><b>Is there another extrinsics consumer? (checked — no)</b></summary>

<br>

`get_extrinsics` had **exactly one caller**: the line this PR changes.

The comment block at `realsense.hpp:918-935` derives the `get_geometries` box pose from the `~= {-14.7, 0, 0} mm` color→depth baseline, but that is documentation only — the poses are hardcoded constants and nothing reads extrinsics at runtime. So there was no internal value that needed preserving. I added a clarifying line so it doesn't read as a runtime dependency.

</details>

<details>
<summary><b>Why the tests are shaped this way</b></summary>

<br>

`get_properties()` isn't unit-testable — it needs an active profile off a live `rs2::pipeline`, which is why `extrinsics_test.cpp` was a placeholder.

So `get_extrinsics` is now templated on the profile type (the same injection idiom `device.hpp` already uses) and tests drive it through a stand-in exposing `unique_id()`/`get_extrinsics_to()`.

The important part: one test asserts a real baseline between two *distinct* streams still converts m→mm correctly. Without it, the identity assertions could pass simply because the function always returned zero.

</details>

<details>
<summary><b>Known, not fixed here: ~6 mm calibration under-correction</b></summary>

<br>

The reported extrinsic appears to under-correct by ~6 mm even back when it was the right thing to apply. Pre-#161 captures fit a translation of (−19.5, −3.5) to (−21.5, −1.0) mm against the reported (−15.0, 0).

That is a 2-DOF fit with non-zero residual, so it reads as a calibration error rather than a calibrated value. Flagging it; out of scope for this PR. Expect residual divergence downstream to not quite reach zero.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)